### PR TITLE
Two lined settings

### DIFF
--- a/workspace/TS100/inc/OLED.hpp
+++ b/workspace/TS100/inc/OLED.hpp
@@ -32,7 +32,8 @@ public:
 	void setRotation(bool leftHanded);  	// Set the rotation for the screen
 	bool getRotation();						// Get the current rotation of the LCD
 	void print(const char* string);				// Draw a string to the current location, with current font
-	void setCursor(int16_t x, int16_t y);    // Set the cursor location
+	void setCursor(int16_t x, int16_t y);    // Set the cursor location by pixels
+	void setCharCursor(int16_t x, int16_t y);  //Set cursor location by chars in current font
 	void setFont(uint8_t fontNumber);		// (Future) Set the font that is being used
 	void drawImage(const uint8_t* buffer, uint8_t x, uint8_t width);
 	// Draws an image to the buffer, at x offset from top to bottom (fixed height renders)

--- a/workspace/TS100/inc/Translation.h
+++ b/workspace/TS100/inc/Translation.h
@@ -9,7 +9,7 @@
 #define TRANSLATION_H_
 
 extern const char* SettingsLongNames[16];
-extern const char* SettingsShortNames[16];
+extern const char* SettingsShortNames[16][2];
 extern const char* SettingsCalibrationWarning;
 extern const char* UVLOWarningString;
 extern const char* SleepingSimpleString;

--- a/workspace/TS100/inc/Translation.h
+++ b/workspace/TS100/inc/Translation.h
@@ -8,8 +8,19 @@
 #ifndef TRANSLATION_H_
 #define TRANSLATION_H_
 
-extern const char* SettingsLongNames[16];
+enum ShortNameType {
+  SHORT_NAME_SINGLE_LINE = 1,
+  SHORT_NAME_DOUBLE_LINE = 2,
+};
+
+/*
+ * When SettingsShortNameType is SHORT_NAME_SINGLE_LINE
+ * use SettingsShortNames as SettingsShortNames[16][1].. second column undefined
+ */
+extern const enum ShortNameType SettingsShortNameType;
 extern const char* SettingsShortNames[16][2];
+
+extern const char* SettingsLongNames[16];
 extern const char* SettingsCalibrationWarning;
 extern const char* UVLOWarningString;
 extern const char* SleepingSimpleString;
@@ -22,6 +33,7 @@ extern const char SettingFalseChar;
 extern const char SettingRightChar;
 extern const char SettingLeftChar;
 extern const char SettingAutoChar;
+
 
 #define LANG_EN
 //#define LANG_RU

--- a/workspace/TS100/src/OLED.cpp
+++ b/workspace/TS100/src/OLED.cpp
@@ -183,6 +183,11 @@ void OLED::setCursor(int16_t x, int16_t y) {
 	cursor_y = y;
 }
 
+void OLED::setCharCursor(int16_t x, int16_t y) {
+  cursor_x = x * fontWidth;
+  cursor_y = y * fontHeight;
+}
+
 void OLED::setFont(uint8_t fontNumber) {
 	if (fontNumber == 1) {
 		//small font

--- a/workspace/TS100/src/Translation.c
+++ b/workspace/TS100/src/Translation.c
@@ -41,6 +41,7 @@ const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 #endif
+
 #ifdef LANG_RU
 const char* SettingsLongNames[16] = {
 	/*These are all the help text for all the settings.*/
@@ -76,6 +77,7 @@ const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 #endif
+
 #ifdef LANG_ES
 const char* SettingsLongNames[16] = {
 	/*These are all the help text for all the settings.*/
@@ -111,6 +113,7 @@ const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 #endif
+
 #ifdef LANG_SE
 const char* SettingsLongNames[16] = {
 	/*These are all the help text for all the settings.*/
@@ -146,6 +149,7 @@ const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 #endif
+
 #ifdef LANG_IT
 const char* SettingsLongNames[16] = {
 	/*These are all the help text for all the settings.*/
@@ -181,6 +185,7 @@ const char SettingRightChar = 'D';
 const char SettingLeftChar = 'S';
 const char SettingAutoChar = 'A';
 #endif
+
 #ifdef LANG_FR
 const char* SettingsLongNames[16] = {
 	/*These are all the help text for all the settings.*/
@@ -216,6 +221,7 @@ const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 #endif
+
 #ifdef LANG_DE
 const char* SettingsLongNames[16] = {
 	/*These are all the help text for all the settings.*/
@@ -251,6 +257,7 @@ const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 #endif
+
 #ifdef LANG_SK
 const char* SettingsLongNames[16] = {
 	/*These are all the help text for all the settings.*/
@@ -286,6 +293,7 @@ const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 #endif
+
 #ifdef LANG_TR
 const char* SettingsLongNames[16] = {
 /*These are all the help text for all the settings.*/
@@ -321,6 +329,7 @@ const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 #endif
+
 #ifdef LANG_HR
 const char* SettingsLongNames[16] = {
 /*These are all the help text for all the settings.*/
@@ -356,21 +365,23 @@ const char SettingRightChar = 'D';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 #endif
+
 //Currently the settings names are not translated
-const char* SettingsShortNames[16] = { /**/
-"PWRSC ",    // Power Source (DC or batt)
-		"STMP ", 	// Sleep Temperature
-		"STME ", 	// Sleep Timeout
-		"SHTME ",    // Shutdown Temperature
-		"MSENSE ",    // Motion sensitivity level
-		"TMPUNT ",			//Temp in F and C
-		"ADVIDL ",    // Advanced idle display mode enable
-		"DSPROT ",    // Display rotation mode
-		"BOOST  ",    // Boost enabled
-		"BTMP ", 	// Boost temperature
-		"ASTART ",    // Automatic Start mode
-		"CLBLNK ",    // Cooldown blink
-		"TMP CAL?",    // Temperature calibration enter menu
-		"RESET? ",    // Settings reset command
-		"CAL VIN?", "ADVSLD ",    //advanced soldering screens
-		};
+const char* SettingsShortNames[16][2] = {
+    /* (<= 11) Power Source (DC or batt) */          {"Power", "source"},
+    /* (<=  9) Sleep Temperature */                  {"Sleep", "temp"},
+    /* (<=  9) Sleep Timeout */                      {"Sleep", "timeout"},
+    /* (<= 11) Shutdown Timeout */                   {"Shutdown", "timeout"},
+    /* (<= 13) Motion sensitivity level */           {"Motion", "sensitivity"},
+    /* (<= 13) Temp in F and C */                    {"Temperature", "units"},
+    /* (<= 13) Advanced idle display mode enable */  {"Detailed", "idle screen"},
+    /* (<= 13) Display rotation mode */              {"Display", "orientation"},
+    /* (<= 13) Boost enabled */                      {"Boost mode", "enabled"},
+    /* (<=  9) Boost temperature */                  {"Boost", "temp"},
+    /* (<= 13) Automatic Start mode */               {"Auto", "start"},
+    /* (<= 13) Cooldown blink */                     {"Cooldown", "blink"},
+    /* (<= 16) Temperature calibration enter menu */ {"Calibrate", "temperature?"},
+    /* (<= 16) Settings reset command */             {"Factory", "Reset?"},
+    /* (<= 16) Calibrate input voltage */            {"Calibrate", "input voltage?"},
+    /* (<= 13) Advanced soldering screens */         {"Detailed", "solder screen"},
+    };

--- a/workspace/TS100/src/Translation.c
+++ b/workspace/TS100/src/Translation.c
@@ -6,6 +6,50 @@
  */
 #include "Translation.h"
 
+// TEMPLATES for short names - choose one and use it as base for your translation:
+
+//const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+//const char* SettingsShortNames[16][2] = {
+//    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+//    /* (<= 4) Sleep temperature                  */ {"STMP"},
+//    /* (<= 4) Sleep timeout                      */ {"STME"},
+//    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+//    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+//    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+//    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+//    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+//    /* (<= 6) Boost enabled                      */ {"BOOST"},
+//    /* (<= 4) Boost temperature                  */ {"BTMP"},
+//    /* (<= 6) Automatic start mode               */ {"ASTART"},
+//    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+//    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+//    /* (<= 8) Settings reset command             */ {"RESET?"},
+//    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+//    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+//};
+
+//const enum ShortNameType SettingsShortNameType = SHORT_NAME_DOUBLE_LINE;
+//const char* SettingsShortNames[16][2] = {
+//    /* (<= 11) Power source (DC or batt)          */ {"Power", "source"},
+//    /* (<=  9) Sleep temperature                  */ {"Sleep", "temp"},
+//    /* (<=  9) Sleep timeout                      */ {"Sleep", "timeout"},
+//    /* (<= 11) Shutdown timeout                   */ {"Shutdown", "timeout"},
+//    /* (<= 13) Motion sensitivity level           */ {"Motion", "sensitivity"},
+//    /* (<= 13) Temperature in F and C             */ {"Temperature", "units"},
+//    /* (<= 13) Advanced idle display mode enabled */ {"Detailed", "idle screen"},
+//    /* (<= 13) Display rotation mode              */ {"Display", "orientation"},
+//    /* (<= 13) Boost enabled                      */ {"Boost mode", "enabled"},
+//    /* (<=  9) Boost temperature                  */ {"Boost", "temp"},
+//    /* (<= 13) Automatic start mode               */ {"Auto", "start"},
+//    /* (<= 13) Cooldown blink                     */ {"Cooldown", "blink"},
+//    /* (<= 16) Temperature calibration enter menu */ {"Calibrate", "temperature?"},
+//    /* (<= 16) Settings reset command             */ {"Factory", "Reset?"},
+//    /* (<= 16) Calibrate input voltage            */ {"Calibrate", "input voltage?"},
+//    /* (<= 13) Advanced soldering screen enabled  */ {"Detailed", "solder screen"},
+//};
+
+
+
 #ifdef LANG_EN
 const char* SettingsLongNames[16] = {
 /*These are all the help text for all the settings.*/
@@ -40,7 +84,29 @@ const char SettingFalseChar = 'F';
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
+
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_DOUBLE_LINE;
+const char* SettingsShortNames[16][2] = {
+    /* (<= 11) Power source (DC or batt)          */ {"Power", "source"},
+    /* (<=  9) Sleep temperature                  */ {"Sleep", "temp"},
+    /* (<=  9) Sleep timeout                      */ {"Sleep", "timeout"},
+    /* (<= 11) Shutdown timeout                   */ {"Shutdown", "timeout"},
+    /* (<= 13) Motion sensitivity level           */ {"Motion", "sensitivity"},
+    /* (<= 13) Temperature in F and C             */ {"Temperature", "units"},
+    /* (<= 13) Advanced idle display mode enabled */ {"Detailed", "idle screen"},
+    /* (<= 13) Display rotation mode              */ {"Display", "orientation"},
+    /* (<= 13) Boost enabled                      */ {"Boost mode", "enabled"},
+    /* (<=  9) Boost temperature                  */ {"Boost", "temp"},
+    /* (<= 13) Automatic start mode               */ {"Auto", "start"},
+    /* (<= 13) Cooldown blink                     */ {"Cooldown", "blink"},
+    /* (<= 16) Temperature calibration enter menu */ {"Calibrate", "temperature?"},
+    /* (<= 16) Settings reset command             */ {"Factory", "Reset?"},
+    /* (<= 16) Calibrate input voltage            */ {"Calibrate", "input voltage?"},
+    /* (<= 13) Advanced soldering screen enabled  */ {"Detailed", "solder screen"},
+};
 #endif
+
+
 
 #ifdef LANG_RU
 const char* SettingsLongNames[16] = {
@@ -76,7 +142,29 @@ const char SettingFalseChar = 'F';
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
+
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+const char* SettingsShortNames[16][2] = {
+    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+    /* (<= 4) Sleep temperature                  */ {"STMP"},
+    /* (<= 4) Sleep timeout                      */ {"STME"},
+    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+    /* (<= 6) Boost enabled                      */ {"BOOST"},
+    /* (<= 4) Boost temperature                  */ {"BTMP"},
+    /* (<= 6) Automatic start mode               */ {"ASTART"},
+    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+    /* (<= 8) Settings reset command             */ {"RESET?"},
+    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+};
 #endif
+
+
 
 #ifdef LANG_ES
 const char* SettingsLongNames[16] = {
@@ -112,7 +200,29 @@ const char SettingFalseChar = 'F';
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
+
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+const char* SettingsShortNames[16][2] = {
+    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+    /* (<= 4) Sleep temperature                  */ {"STMP"},
+    /* (<= 4) Sleep timeout                      */ {"STME"},
+    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+    /* (<= 6) Boost enabled                      */ {"BOOST"},
+    /* (<= 4) Boost temperature                  */ {"BTMP"},
+    /* (<= 6) Automatic start mode               */ {"ASTART"},
+    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+    /* (<= 8) Settings reset command             */ {"RESET?"},
+    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+};
 #endif
+
+
 
 #ifdef LANG_SE
 const char* SettingsLongNames[16] = {
@@ -148,7 +258,29 @@ const char SettingFalseChar = 'F';
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
+
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+const char* SettingsShortNames[16][2] = {
+    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+    /* (<= 4) Sleep temperature                  */ {"STMP"},
+    /* (<= 4) Sleep timeout                      */ {"STME"},
+    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+    /* (<= 6) Boost enabled                      */ {"BOOST"},
+    /* (<= 4) Boost temperature                  */ {"BTMP"},
+    /* (<= 6) Automatic start mode               */ {"ASTART"},
+    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+    /* (<= 8) Settings reset command             */ {"RESET?"},
+    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+};
 #endif
+
+
 
 #ifdef LANG_IT
 const char* SettingsLongNames[16] = {
@@ -184,7 +316,29 @@ const char SettingFalseChar = 'D';
 const char SettingRightChar = 'D';
 const char SettingLeftChar = 'S';
 const char SettingAutoChar = 'A';
+
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+const char* SettingsShortNames[16][2] = {
+    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+    /* (<= 4) Sleep temperature                  */ {"STMP"},
+    /* (<= 4) Sleep timeout                      */ {"STME"},
+    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+    /* (<= 6) Boost enabled                      */ {"BOOST"},
+    /* (<= 4) Boost temperature                  */ {"BTMP"},
+    /* (<= 6) Automatic start mode               */ {"ASTART"},
+    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+    /* (<= 8) Settings reset command             */ {"RESET?"},
+    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+};
 #endif
+
+
 
 #ifdef LANG_FR
 const char* SettingsLongNames[16] = {
@@ -220,7 +374,29 @@ const char SettingFalseChar = 'F';
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
+
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+const char* SettingsShortNames[16][2] = {
+    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+    /* (<= 4) Sleep temperature                  */ {"STMP"},
+    /* (<= 4) Sleep timeout                      */ {"STME"},
+    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+    /* (<= 6) Boost enabled                      */ {"BOOST"},
+    /* (<= 4) Boost temperature                  */ {"BTMP"},
+    /* (<= 6) Automatic start mode               */ {"ASTART"},
+    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+    /* (<= 8) Settings reset command             */ {"RESET?"},
+    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+};
 #endif
+
+
 
 #ifdef LANG_DE
 const char* SettingsLongNames[16] = {
@@ -256,7 +432,29 @@ const char SettingFalseChar = 'F';
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
+
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+const char* SettingsShortNames[16][2] = {
+    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+    /* (<= 4) Sleep temperature                  */ {"STMP"},
+    /* (<= 4) Sleep timeout                      */ {"STME"},
+    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+    /* (<= 6) Boost enabled                      */ {"BOOST"},
+    /* (<= 4) Boost temperature                  */ {"BTMP"},
+    /* (<= 6) Automatic start mode               */ {"ASTART"},
+    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+    /* (<= 8) Settings reset command             */ {"RESET?"},
+    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+};
 #endif
+
+
 
 #ifdef LANG_SK
 const char* SettingsLongNames[16] = {
@@ -292,7 +490,29 @@ const char SettingFalseChar = 'F';
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
+
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+const char* SettingsShortNames[16][2] = {
+    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+    /* (<= 4) Sleep temperature                  */ {"STMP"},
+    /* (<= 4) Sleep timeout                      */ {"STME"},
+    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+    /* (<= 6) Boost enabled                      */ {"BOOST"},
+    /* (<= 4) Boost temperature                  */ {"BTMP"},
+    /* (<= 6) Automatic start mode               */ {"ASTART"},
+    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+    /* (<= 8) Settings reset command             */ {"RESET?"},
+    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+};
 #endif
+
+
 
 #ifdef LANG_TR
 const char* SettingsLongNames[16] = {
@@ -328,7 +548,29 @@ const char SettingFalseChar = 'F';
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
+
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+const char* SettingsShortNames[16][2] = {
+    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+    /* (<= 4) Sleep temperature                  */ {"STMP"},
+    /* (<= 4) Sleep timeout                      */ {"STME"},
+    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+    /* (<= 6) Boost enabled                      */ {"BOOST"},
+    /* (<= 4) Boost temperature                  */ {"BTMP"},
+    /* (<= 6) Automatic start mode               */ {"ASTART"},
+    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+    /* (<= 8) Settings reset command             */ {"RESET?"},
+    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+};
 #endif
+
+
 
 #ifdef LANG_HR
 const char* SettingsLongNames[16] = {
@@ -364,24 +606,24 @@ const char SettingFalseChar = '-';
 const char SettingRightChar = 'D';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
-#endif
 
-//Currently the settings names are not translated
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
 const char* SettingsShortNames[16][2] = {
-    /* (<= 11) Power Source (DC or batt) */          {"Power", "source"},
-    /* (<=  9) Sleep Temperature */                  {"Sleep", "temp"},
-    /* (<=  9) Sleep Timeout */                      {"Sleep", "timeout"},
-    /* (<= 11) Shutdown Timeout */                   {"Shutdown", "timeout"},
-    /* (<= 13) Motion sensitivity level */           {"Motion", "sensitivity"},
-    /* (<= 13) Temp in F and C */                    {"Temperature", "units"},
-    /* (<= 13) Advanced idle display mode enable */  {"Detailed", "idle screen"},
-    /* (<= 13) Display rotation mode */              {"Display", "orientation"},
-    /* (<= 13) Boost enabled */                      {"Boost mode", "enabled"},
-    /* (<=  9) Boost temperature */                  {"Boost", "temp"},
-    /* (<= 13) Automatic Start mode */               {"Auto", "start"},
-    /* (<= 13) Cooldown blink */                     {"Cooldown", "blink"},
-    /* (<= 16) Temperature calibration enter menu */ {"Calibrate", "temperature?"},
-    /* (<= 16) Settings reset command */             {"Factory", "Reset?"},
-    /* (<= 16) Calibrate input voltage */            {"Calibrate", "input voltage?"},
-    /* (<= 13) Advanced soldering screens */         {"Detailed", "solder screen"},
-    };
+    /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+    /* (<= 4) Sleep temperature                  */ {"STMP"},
+    /* (<= 4) Sleep timeout                      */ {"STME"},
+    /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+    /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+    /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+    /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+    /* (<= 6) Display rotation mode              */ {"DSPROT"},
+    /* (<= 6) Boost enabled                      */ {"BOOST"},
+    /* (<= 4) Boost temperature                  */ {"BTMP"},
+    /* (<= 6) Automatic start mode               */ {"ASTART"},
+    /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+    /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+    /* (<= 8) Settings reset command             */ {"RESET?"},
+    /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+    /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+};
+#endif

--- a/workspace/TS100/src/Translation.c
+++ b/workspace/TS100/src/Translation.c
@@ -52,25 +52,25 @@
 
 #ifdef LANG_EN
 const char* SettingsLongNames[16] = {
-/*These are all the help text for all the settings.*/
-/*No requirements on spacing or length*/
-"Power source. Sets cutoff voltage. <DC 10V> <S 3.3V per cell>",    //Power Source
-		"Sleep Temperature <C>",    //Sleep Temp
-		"Sleep Timeout <Minutes/Seconds>",    //Sleep Timeout
-		"Shutdown Timeout <Minutes>",    //Shutdown Time
-		"Motion Sensitivity <0.Off 1.least sensitive 9.most sensitive>",    //Motion Sensitivity
-		"Temperature Unit <C=Celsius F=Fahrenheit>",    //Temp Unit
-		"Display detailed information in a smaller font on the idle screen.",    //Detailed Information
-		"Display Orientation <A. Automatic L. Left Handed R. Right Handed>",    //Orientation
-		"Enable front key enters boost mode 450C mode when soldering",    //Boost enable
-		"Temperature when in \"boost\" mode",    //Boost Temp
-		"Automatically starts the iron into soldering on power up. T=Soldering, S= Sleep mode,F=Off",    //Auto start
-		"Blink the temperature on the cooling screen while the tip is still hot.",    //Cooling Blink
-		"Calibrate tip offset.",    //Calibrate Tip
-		"Reset all settings",    //Reset Settings
-		"VIN Calibration. Buttons adjust, long press to exit",    //VIN Cal
-		"Display detailed information while soldering",    //ADV SLD
-		};
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Power source. Sets cutoff voltage. <DC 10V> <S 3.3V per cell>",
+    /* Sleep temperature                  */ "Sleep Temperature <C>",
+    /* Sleep timeout                      */ "Sleep Timeout <Minutes/Seconds>",
+    /* Shutdown timeout                   */ "Shutdown Timeout <Minutes>",
+    /* Motion sensitivity level           */ "Motion Sensitivity <0.Off 1.least sensitive 9.most sensitive>",
+    /* Temperature in F and C             */ "Temperature Unit <C=Celsius F=Fahrenheit>",
+    /* Advanced idle display mode enabled */ "Display detailed information in a smaller font on the idle screen.",
+    /* Display rotation mode              */ "Display Orientation <A. Automatic L. Left Handed R. Right Handed>",
+    /* Boost enabled                      */ "Enable front key enters boost mode 450C mode when soldering",
+    /* Boost temperature                  */ "Temperature when in \"boost\" mode",
+    /* Automatic start mode               */ "Automatically starts the iron into soldering on power up. T=Soldering, S= Sleep mode,F=Off",
+    /* Cooldown blink                     */ "Blink the temperature on the cooling screen while the tip is still hot.",
+    /* Temperature calibration enter menu */ "Calibrate tip offset.",
+    /* Settings reset command             */ "Reset all settings",
+    /* Calibrate input voltage            */ "VIN Calibration. Buttons adjust, long press to exit",
+    /* Advanced soldering screen enabled  */ "Display detailed information while soldering",
+};
 
 const char* SettingsCalibrationWarning = "Please ensure the tip is at room temperature before continuing!";
 const char* UVLOWarningString = "LOW VOLT";    //Fixed width 8 chars
@@ -110,24 +110,24 @@ const char* SettingsShortNames[16][2] = {
 
 #ifdef LANG_RU
 const char* SettingsLongNames[16] = {
-	/*These are all the help text for all the settings.*/
-	/*No requirements on spacing or length*/
-	"Источник питания. Установка напряжения отключения. <DC 10V> <S 3.3 V на батарею>",    //Cell count
-	"Температура Сна  <С>",//Sleep Temp
-	"Переход в режим Сна <Минуты>",//Sleep timeout
-	"Переходит в режим ожидания <Минуты>",//Shutdown timeout
-	"Акселерометр <0. Выкл. 1. мин. чувствительный 9. макс. чувствительный>",//Sensitivity
-	"В чем измерять температуру",//Temp Unit
-	"Display detailed information in a smaller font on the idle screen.",//Detailed Information
-	"Ориентация Дисплея <A. Автоматический L. Левая Рука R. Правая Рука>",//Orientation
-	"Активация  кнопки A для Турбо режима до  450С при пайке ",//Boost enable
-	"Установка температуры для Турбо режима",//Boost temp
-	"Автоматический запуск паяльника при включении питания. T=Нагрев, S= Режим Сна,F=Выкл.",//Auto start
-	"Мигает температура на экране охлаждения, пока жало остается горячим."//Cooling blink
-	"Calibrate tip offset.",//Calibrate Tip
-	"Reset all settings",//Reset Settings
-	"VIN Calibration. Buttons adjust, long press to exit",//VIN Cal
-	"Display detailed information while soldering",//ADV SLD
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Источник питания. Установка напряжения отключения. <DC 10V> <S 3.3 V на батарею>",
+    /* Sleep temperature                  */ "Температура Сна  <С>",
+    /* Sleep timeout                      */ "Переход в режим Сна <Минуты>",
+    /* Shutdown timeout                   */ "Переходит в режим ожидания <Минуты>",
+    /* Motion sensitivity level           */ "Акселерометр <0. Выкл. 1. мин. чувствительный 9. макс. чувствительный>",
+    /* Temperature in F and C             */ "В чем измерять температуру",
+    /* Advanced idle display mode enabled */ "Display detailed information in a smaller font on the idle screen.",
+    /* Display rotation mode              */ "Ориентация Дисплея <A. Автоматический L. Левая Рука R. Правая Рука>",
+    /* Boost enabled                      */ "Активация  кнопки A для Турбо режима до  450С при пайке ",
+    /* Boost temperature                  */ "Установка температуры для Турбо режима",
+    /* Automatic start mode               */ "Автоматический запуск паяльника при включении питания. T=Нагрев, S= Режим Сна,F=Выкл.",
+    /* Cooldown blink                     */ "Мигает температура на экране охлаждения, пока жало остается горячим."
+    /* Temperature calibration enter menu */ "Calibrate tip offset.",
+    /* Settings reset command             */ "Reset all settings",
+    /* Calibrate input voltage            */ "VIN Calibration. Buttons adjust, long press to exit",
+    /* Advanced soldering screen enabled  */ "Display detailed information while soldering",
 };
 
 const char* SettingsCalibrationWarning = "Please ensure the tip is at room temperature before continuing!";
@@ -168,24 +168,24 @@ const char* SettingsShortNames[16][2] = {
 
 #ifdef LANG_ES
 const char* SettingsLongNames[16] = {
-	/*These are all the help text for all the settings.*/
-	/*No requirements on spacing or length*/
-	"Fuente de energía. Ajusta el límite inferior de voltaje. <DC=10V S=3.3V por celda>",
-	"Temperatura en reposo. <C>",
-	"Tiempo hasta activar reposo. <Minutos>",
-	"Tiempo hasta apagado. <Minutos>",
-	"Sensibilidad del movimiento. <0=Apagado 1=El menos sensible 9=El más sensible>",
-	"Unidad de temperatura.",
-	"Display detailed information in a smaller font on the idle screen.",    //Detailed Information
-	"Orientación de la pantalla <A=Automático I=Mano izquierda D=Mano derecha>",
-	"Activar el botón \"Boost\" en modo soldadura.",
-	"Temperatura en modo \"Boost\". <C>",
-	"Iniciar modo soldadura en el encendido. <V=Sí S=Modo reposo F=No>",
-	"Parpadea la temperatura en el enfriamiento si la punta sigue caliente."
-	"Calibrate tip offset.",//Calibrate Tip
-	"Reset all settings",//Reset Settings
-	"VIN Calibration. Buttons adjust, long press to exit",//VIN Cal
-	"Display detailed information while soldering",//ADV SLD
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Fuente de energía. Ajusta el límite inferior de voltaje. <DC=10V S=3.3V por celda>",
+    /* Sleep temperature                  */ "Temperatura en reposo. <C>",
+    /* Sleep timeout                      */ "Tiempo hasta activar reposo. <Minutos>",
+    /* Shutdown timeout                   */ "Tiempo hasta apagado. <Minutos>",
+    /* Motion sensitivity level           */ "Sensibilidad del movimiento. <0=Apagado 1=El menos sensible 9=El más sensible>",
+    /* Temperature in F and C             */ "Unidad de temperatura.",
+    /* Advanced idle display mode enabled */ "Display detailed information in a smaller font on the idle screen.",
+    /* Display rotation mode              */ "Orientación de la pantalla <A=Automático I=Mano izquierda D=Mano derecha>",
+    /* Boost enabled                      */ "Activar el botón \"Boost\" en modo soldadura.",
+    /* Boost temperature                  */ "Temperatura en modo \"Boost\". <C>",
+    /* Automatic start mode               */ "Iniciar modo soldadura en el encendido. <V=Sí S=Modo reposo F=No>",
+    /* Cooldown blink                     */ "Parpadea la temperatura en el enfriamiento si la punta sigue caliente."
+    /* Temperature calibration enter menu */ "Calibrate tip offset.",
+    /* Settings reset command             */ "Reset all settings",
+    /* Calibrate input voltage            */ "VIN Calibration. Buttons adjust, long press to exit",
+    /* Advanced soldering screen enabled  */ "Display detailed information while soldering",
 };
 
 const char* SettingsCalibrationWarning = "Please ensure the tip is at room temperature before continuing!";
@@ -226,24 +226,24 @@ const char* SettingsShortNames[16][2] = {
 
 #ifdef LANG_SE
 const char* SettingsLongNames[16] = {
-	/*These are all the help text for all the settings.*/
-	/*No requirements on spacing or length*/
-	"Источник питания. Установка напряжения отключения. <DC 10V> <S 3.3 V на батарею>",    //Cell count
-	"Температура Сна  <С>",//Sleep Temp
-	"Переход в режим Сна <Минуты>",//Sleep timeout
-	"Переходит в режим ожидания <Минуты>",//Shutdown timeout
-	"Акселерометр <0. Выкл. 1. мин. чувствительный 9. макс. чувствительный>",//Sensitivity
-	"В чем измерять температуру",//Temp Unit
-	"Display detailed information in a smaller font on the idle screen.",//Detailed Information
-	"Ориентация Дисплея <A. Автоматический L. Левая Рука R. Правая Рука>",//Orientation
-	"Активация  кнопки A для Турбо режима до  450С при пайке ",//Boost enable
-	"Установка температуры для Турбо режима",//Boost temp
-	"Автоматический запуск паяльника при включении питания. T=Нагрев, S= Режим Сна,F=Выкл.",//Auto start
-	"Мигает температура на экране охлаждения, пока жало остается горячим."//Cooling blink
-	"Calibrate tip offset.",//Calibrate Tip
-	"Reset all settings",//Reset Settings
-	"VIN Calibration. Buttons adjust, long press to exit",//VIN Cal
-	"Display detailed information while soldering",//ADV SLD
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Источник питания. Установка напряжения отключения. <DC 10V> <S 3.3 V на батарею>",
+    /* Sleep temperature                  */ "Температура Сна  <С>",
+    /* Sleep timeout                      */ "Переход в режим Сна <Минуты>",
+    /* Shutdown timeout                   */ "Переходит в режим ожидания <Минуты>",
+    /* Motion sensitivity level           */ "Акселерометр <0. Выкл. 1. мин. чувствительный 9. макс. чувствительный>",
+    /* Temperature in F and C             */ "В чем измерять температуру",
+    /* Advanced idle display mode enabled */ "Display detailed information in a smaller font on the idle screen.",
+    /* Display rotation mode              */ "Ориентация Дисплея <A. Автоматический L. Левая Рука R. Правая Рука>",
+    /* Boost enabled                      */ "Активация  кнопки A для Турбо режима до  450С при пайке ",
+    /* Boost temperature                  */ "Установка температуры для Турбо режима",
+    /* Automatic start mode               */ "Автоматический запуск паяльника при включении питания. T=Нагрев, S= Режим Сна,F=Выкл.",
+    /* Cooldown blink                     */ "Мигает температура на экране охлаждения, пока жало остается горячим."
+    /* Temperature calibration enter menu */ "Calibrate tip offset.",
+    /* Settings reset command             */ "Reset all settings",
+    /* Calibrate input voltage            */ "VIN Calibration. Buttons adjust, long press to exit",
+    /* Advanced soldering screen enabled  */ "Display detailed information while soldering",
 };
 
 const char* SettingsCalibrationWarning = "Please ensure the tip is at room temperature before continuing!";
@@ -284,24 +284,24 @@ const char* SettingsShortNames[16][2] = {
 
 #ifdef LANG_IT
 const char* SettingsLongNames[16] = {
-	/*These are all the help text for all the settings.*/
-	/*No requirements on spacing or length*/
-	"Sorgente di alimentazione; imposta il limite minimo di tensione <DC: 10V; S: 3.3V per cella>",
-	"Temperatura standby <°C>",
-	"Timeout standby <minuti/secondi>",
-	"Timeout spegnimento <minuti>",
-	"Sensibilità al movimento <0: nessuna; 1: minima; 9: massima>",
-	"Unità di misura della temperatura <C: Celsius; F: Farenheit>",
-	"Mostra informazioni dettagliate con un carattere più piccolo sulla schermata di inattività",
-	"Orientamento del display <A: automatico; S: mano sinistra; D: mano destra>",
-	"Il tasto anteriore attiva la modalità \"boost\" durante la saldatura",
-	"Temperatura in modalità \"boost\"",
-	"Attiva automaticamente il saldatore quando viene alimentato <A: saldatura; S: standby; D: disattiva>",
-	"Durante il raffreddamento mostra la temperatura sul display se la punta è ancora calda"
-	"Calibra l'offset della punta",//Calibrate Tip
-	"Ripristina tutte le impostazioni",//Reset Settings
-	"Calibra la tensione in entrata; regola con i bottoni, tieni permuto per uscire",//VIN Cal
-	"Mostra informazioni dettagliate mentre stai saldando",//ADV SLD
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Sorgente di alimentazione; imposta il limite minimo di tensione <DC: 10V; S: 3.3V per cella>",
+    /* Sleep temperature                  */ "Temperatura standby <°C>",
+    /* Sleep timeout                      */ "Timeout standby <minuti/secondi>",
+    /* Shutdown timeout                   */ "Timeout spegnimento <minuti>",
+    /* Motion sensitivity level           */ "Sensibilità al movimento <0: nessuna; 1: minima; 9: massima>",
+    /* Temperature in F and C             */ "Unità di misura della temperatura <C: Celsius; F: Farenheit>",
+    /* Advanced idle display mode enabled */ "Mostra informazioni dettagliate con un carattere più piccolo sulla schermata di inattività",
+    /* Display rotation mode              */ "Orientamento del display <A: automatico; S: mano sinistra; D: mano destra>",
+    /* Boost enabled                      */ "Il tasto anteriore attiva la modalità \"boost\" durante la saldatura",
+    /* Boost temperature                  */ "Temperatura in modalità \"boost\"",
+    /* Automatic start mode               */ "Attiva automaticamente il saldatore quando viene alimentato <A: saldatura; S: standby; D: disattiva>",
+    /* Cooldown blink                     */ "Durante il raffreddamento mostra la temperatura sul display se la punta è ancora calda"
+    /* Temperature calibration enter menu */ "Calibra l'offset della punta",
+    /* Settings reset command             */ "Ripristina tutte le impostazioni",
+    /* Calibrate input voltage            */ "Calibra la tensione in entrata; regola con i bottoni, tieni permuto per uscire",
+    /* Advanced soldering screen enabled  */ "Mostra informazioni dettagliate mentre stai saldando",
 };
 
 const char* SettingsCalibrationWarning = "Assicurati che la punta si trovi a temperatura ambiente prima di continuare!";
@@ -342,24 +342,24 @@ const char* SettingsShortNames[16][2] = {
 
 #ifdef LANG_FR
 const char* SettingsLongNames[16] = {
-	/*These are all the help text for all the settings.*/
-	/*No requirements on spacing or length*/
-	"Type d\'alimentation. Regle la tension de coupure. <DC=10V S=3.3V par cellules>",
-	"Temperature en veille. <C>",
-	"Temps avant mise en veille. <Minutes>",
-	"Temps avant extinction. <Minutes>",
-	"Sensibilitee du capteur de mouvement. <0=Inactif 1=Peu sensible 9=Tres sensible>",
-	"Unitee de temperature.",
-	"Afficher des informations detaillees en petit lors de la veille",    //Detailed Information
-	"Orientation de l\'affichage. <A=Automatique G=Gaucher D=Droitier>",
-	"Active le mode \"Boost\" 450C sur le bouton de devant pendant la soudure.",
-	"Temperature du mode \"Boost\". <C>",
-	"Demarre automatiquement la soudure a l\'allumage. <A=Active, V=Mode Veille, D=Desactive>",
-	"Fait clignotter la temperature lors du refroidissement pendant que la panne est chaude."
-	"Compenser l\'erreur de la panne",//Calibrate Tip
-	"Reinitialiser tout les reglages",//Reset Settings
-	"Calibration VIN. Boutons pour ajuster, appui long pour quitter",//VIN Cal
-	"Afficher des informations detaillees pendant la soudure",//ADV SLD
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Type d\'alimentation. Regle la tension de coupure. <DC=10V S=3.3V par cellules>",
+    /* Sleep temperature                  */ "Temperature en veille. <C>",
+    /* Sleep timeout                      */ "Temps avant mise en veille. <Minutes>",
+    /* Shutdown timeout                   */ "Temps avant extinction. <Minutes>",
+    /* Motion sensitivity level           */ "Sensibilitee du capteur de mouvement. <0=Inactif 1=Peu sensible 9=Tres sensible>",
+    /* Temperature in F and C             */ "Unitee de temperature.",
+    /* Advanced idle display mode enabled */ "Afficher des informations detaillees en petit lors de la veille",
+    /* Display rotation mode              */ "Orientation de l\'affichage. <A=Automatique G=Gaucher D=Droitier>",
+    /* Boost enabled                      */ "Active le mode \"Boost\" 450C sur le bouton de devant pendant la soudure.",
+    /* Boost temperature                  */ "Temperature du mode \"Boost\". <C>",
+    /* Automatic start mode               */ "Demarre automatiquement la soudure a l\'allumage. <A=Active, V=Mode Veille, D=Desactive>",
+    /* Cooldown blink                     */ "Fait clignotter la temperature lors du refroidissement pendant que la panne est chaude."
+    /* Temperature calibration enter menu */ "Compenser l\'erreur de la panne",
+    /* Settings reset command             */ "Reinitialiser tout les reglages",
+    /* Calibrate input voltage            */ "Calibration VIN. Boutons pour ajuster, appui long pour quitter",
+    /* Advanced soldering screen enabled  */ "Afficher des informations detaillees pendant la soudure",
 };
 
 const char* SettingsCalibrationWarning = "Please ensure the tip is at room temperature before continuing!";
@@ -400,24 +400,24 @@ const char* SettingsShortNames[16][2] = {
 
 #ifdef LANG_DE
 const char* SettingsLongNames[16] = {
-	/*These are all the help text for all the settings.*/
-	/*No requirements on spacing or length*/
-	"Spannungsquelle (Abschaltspannung) <DC=10V, nS=n*3.3V für n LiIon-Zellen>",
-	"Ruhetemperatur (In der eingestellten Einheit)",
-	"Ruhemodus nach <Sekunden/Minuten>",
-	"Abschaltzeit <Minuten>",
-	"Bewegungsempfindlichkeit <0=Aus, 1=Minimal ... 9=Maximal>",
-	"Temperatureinheit <C=Celsius, F=Fahrenheit>",
-	"Detaillierte Anzeige im Ruhemodus <T=An, F=Aus>",    //Detailed Information
-	"Ausrichtung der Anzeige <A=Auto, L=Linkshändig, R=Rechtshändig>",
-	"Vordere Taste für Temperaturboost verwenden <T=An, F=Aus>",
-	"Temperatur im Boostmodus  (In der eingestellten Einheit)",
-	"Automatischer Start des Lötmodus beim Einschalten der Spannungsversorgung. <T=An, F=Aus>",
-	"Blinkende Temperaturanzeige beim Abkühlen, solange heiß. <T=An, F=Aus>"
-	"Kalibrierung der Lötspitzentemperatur",//Calibrate Tip
-	"Alle Einstellungen zurücksetzen",//Reset Settings
-	"Kalibrierung der Eingangsspannung. Kurzer Tastendruck zum Einstellen, langer Tastendruck zum Verlassen.",//VIN Cal
-	"Detaillierte Anzeige im Lötmodus <T=An, F=Aus>",//ADV SLD
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Spannungsquelle (Abschaltspannung) <DC=10V, nS=n*3.3V für n LiIon-Zellen>",
+    /* Sleep temperature                  */ "Ruhetemperatur (In der eingestellten Einheit)",
+    /* Sleep timeout                      */ "Ruhemodus nach <Sekunden/Minuten>",
+    /* Shutdown timeout                   */ "Abschaltzeit <Minuten>",
+    /* Motion sensitivity level           */ "Bewegungsempfindlichkeit <0=Aus, 1=Minimal ... 9=Maximal>",
+    /* Temperature in F and C             */ "Temperatureinheit <C=Celsius, F=Fahrenheit>",
+    /* Advanced idle display mode enabled */ "Detaillierte Anzeige im Ruhemodus <T=An, F=Aus>",
+    /* Display rotation mode              */ "Ausrichtung der Anzeige <A=Auto, L=Linkshändig, R=Rechtshändig>",
+    /* Boost enabled                      */ "Vordere Taste für Temperaturboost verwenden <T=An, F=Aus>",
+    /* Boost temperature                  */ "Temperatur im Boostmodus  (In der eingestellten Einheit)",
+    /* Automatic start mode               */ "Automatischer Start des Lötmodus beim Einschalten der Spannungsversorgung. <T=An, F=Aus>",
+    /* Cooldown blink                     */ "Blinkende Temperaturanzeige beim Abkühlen, solange heiß. <T=An, F=Aus>"
+    /* Temperature calibration enter menu */ "Kalibrierung der Lötspitzentemperatur",
+    /* Settings reset command             */ "Alle Einstellungen zurücksetzen",
+    /* Calibrate input voltage            */ "Kalibrierung der Eingangsspannung. Kurzer Tastendruck zum Einstellen, langer Tastendruck zum Verlassen.",
+    /* Advanced soldering screen enabled  */ "Detaillierte Anzeige im Lötmodus <T=An, F=Aus>",
 };
 
 const char* SettingsCalibrationWarning = "Vor dem Fortfahren muss die Lötspitze vollständig abgekühlt sein!";
@@ -458,24 +458,24 @@ const char* SettingsShortNames[16][2] = {
 
 #ifdef LANG_SK
 const char* SettingsLongNames[16] = {
-	/*These are all the help text for all the settings.*/
-	/*No requirements on spacing or length*/
-	"Zdroj napatia. Nastavit napatie pre vypnutie (cutoff)  <DC=10V, nS=n*3.3V pre LiIon clanky>",
-	"Kludova teplota (v nastavenych jednotkach)",
-	"Kludovy rezim po <sekundach/minutach>",
-	"Cas na vypnutie <minuty>",
-	"Citlivost detekcie pohybu <0=Vyp, 1=Min ... 9=Max>",
-	"Jednotky merania teploty <C=stupne Celzia, F=stupne Fahrenheita>",
-	"Zobrazit detailne informacie v kludovom rezime <T=Zap, F=Vyp>",    //Detailed Information
-	"Orientacia displeja <A=Auto, L=Lavak, R=Pravak>",
-	"Povolit tlacidlo pre prudky nahrev <T=Zap, F=Vyp>",
-	"Cielova teplota pre prudky nahrev (v nastavenych jednotkach)",
-	"Pri starte spustit rezim spajkovania <T=Zap, F=Vyp, S=Spanok>",
-	"Blikanie ukazovatela teploty pocas chladnutia hrotu <T=Zap, F=Vyp>"
-	"Kalibracia posunu hrotu",//Calibrate Tip
-	"Tovarenske nastavenia",//Reset Settings
-	"Kalibracia VIN. Kratke stlacenie meni nastavenie, dlhe stlacenie pre navrat",//VIN Cal
-	"Zobrazenie detailov pocas spajkovania <T=Zap, F=Vyp>",//ADV SLD
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Zdroj napatia. Nastavit napatie pre vypnutie (cutoff)  <DC=10V, nS=n*3.3V pre LiIon clanky>",
+    /* Sleep temperature                  */ "Kludova teplota (v nastavenych jednotkach)",
+    /* Sleep timeout                      */ "Kludovy rezim po <sekundach/minutach>",
+    /* Shutdown timeout                   */ "Cas na vypnutie <minuty>",
+    /* Motion sensitivity level           */ "Citlivost detekcie pohybu <0=Vyp, 1=Min ... 9=Max>",
+    /* Temperature in F and C             */ "Jednotky merania teploty <C=stupne Celzia, F=stupne Fahrenheita>",
+    /* Advanced idle display mode enabled */ "Zobrazit detailne informacie v kludovom rezime <T=Zap, F=Vyp>",
+    /* Display rotation mode              */ "Orientacia displeja <A=Auto, L=Lavak, R=Pravak>",
+    /* Boost enabled                      */ "Povolit tlacidlo pre prudky nahrev <T=Zap, F=Vyp>",
+    /* Boost temperature                  */ "Cielova teplota pre prudky nahrev (v nastavenych jednotkach)",
+    /* Automatic start mode               */ "Pri starte spustit rezim spajkovania <T=Zap, F=Vyp, S=Spanok>",
+    /* Cooldown blink                     */ "Blikanie ukazovatela teploty pocas chladnutia hrotu <T=Zap, F=Vyp>"
+    /* Temperature calibration enter menu */ "Kalibracia posunu hrotu",
+    /* Settings reset command             */ "Tovarenske nastavenia",
+    /* Calibrate input voltage            */ "Kalibracia VIN. Kratke stlacenie meni nastavenie, dlhe stlacenie pre navrat",
+    /* Advanced soldering screen enabled  */ "Zobrazenie detailov pocas spajkovania <T=Zap, F=Vyp>",
 };
 
 const char* SettingsCalibrationWarning = "Najprv sa prosim uistite, ze hrot ma izbovu teplotu!";
@@ -516,25 +516,25 @@ const char* SettingsShortNames[16][2] = {
 
 #ifdef LANG_TR
 const char* SettingsLongNames[16] = {
-/*These are all the help text for all the settings.*/
-/*No requirements on spacing or length*/
-"Güç Kaynağı. kesim geriliminı ayarlar. <DC 10V> <S 3.3V hücre başına>",    //Power Source
-		"Uyku Sıcaklığı <C>",    //Sleep Temp
-		"Uyku Zaman Aşımı <Dakika/Saniye>",    //Sleep Timeout
-		"Kapatma Zaman Aşımı <Dakika>",    //Shutdown Time
-		"Hareket Hassasiyeti <0.Kapalı 1.En az duyarlı 9.En duyarlı>",    //Motion Sensitivity
-		"Sıcaklık Ünitesi <C=Celsius F=Fahrenheit>",    //Temp Unit
-		"Boş ekranda ayrıntılı bilgileri daha küçük bir yazı tipi ile göster.",    //Detailed Information
-		"Görüntü Yönlendirme <A. Otomatik L. Solak R. Sağlak>",    //Orientation
-		"Lehimleme yaparken ön tuşa basmak Boost moduna sokar(450C)",    //Boost enable
-		"\"boost\" Modu Derecesi",    //Boost Temp
-		"Güç verildiğinde otomatik olarak lehimleme modunda başlat. T=Lehimleme Modu, S= Uyku Modu,F=Kapalı",    //Auto start
-		"Soğutma ekranında uç hala sıcakken derece yanıp sönsün.",    //Cooling Blink
-		"Ucu kalibre et.",    //Calibrate Tip
-		"Bütün ayarları sıfırla",    //Reset Settings
-		"VIN Kalibrasyonu. Düğmeler ayarlar, çıkmak için uzun bas.",    //VIN Cal
-		"Lehimleme yaparken detaylı bilgi göster",    //ADV SLD
-		};
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Güç Kaynağı. kesim geriliminı ayarlar. <DC 10V> <S 3.3V hücre başına>",
+    /* Sleep temperature                  */ "Uyku Sıcaklığı <C>",
+    /* Sleep timeout                      */ "Uyku Zaman Aşımı <Dakika/Saniye>",
+    /* Shutdown timeout                   */ "Kapatma Zaman Aşımı <Dakika>",
+    /* Motion sensitivity level           */ "Hareket Hassasiyeti <0.Kapalı 1.En az duyarlı 9.En duyarlı>",
+    /* Temperature in F and C             */ "Sıcaklık Ünitesi <C=Celsius F=Fahrenheit>",
+    /* Advanced idle display mode enabled */ "Boş ekranda ayrıntılı bilgileri daha küçük bir yazı tipi ile göster.",
+    /* Display rotation mode              */ "Görüntü Yönlendirme <A. Otomatik L. Solak R. Sağlak>",
+    /* Boost enabled                      */ "Lehimleme yaparken ön tuşa basmak Boost moduna sokar(450C)",
+    /* Boost temperature                  */ "\"boost\" Modu Derecesi",
+    /* Automatic start mode               */ "Güç verildiğinde otomatik olarak lehimleme modunda başlat. T=Lehimleme Modu, S= Uyku Modu,F=Kapalı",
+    /* Cooldown blink                     */ "Soğutma ekranında uç hala sıcakken derece yanıp sönsün.",
+    /* Temperature calibration enter menu */ "Ucu kalibre et.",
+    /* Settings reset command             */ "Bütün ayarları sıfırla",
+    /* Calibrate input voltage            */ "VIN Kalibrasyonu. Düğmeler ayarlar, çıkmak için uzun bas.",
+    /* Advanced soldering screen enabled  */ "Lehimleme yaparken detaylı bilgi göster",
+};
 
 const char* SettingsCalibrationWarning = "Lütfen devam etmeden önce ucun oda sıcaklığında olduğunu garantiye alın!";
 const char* UVLOWarningString = "LOW VOLT";    //Fixed width 8 chars
@@ -574,25 +574,25 @@ const char* SettingsShortNames[16][2] = {
 
 #ifdef LANG_HR
 const char* SettingsLongNames[16] = {
-/*These are all the help text for all the settings.*/
-/*No requirements on spacing or length*/
-"Izvor napajanja. Postavlja napon iskljucivanja. <DC 10V> <S 3.3V po celiji>",    //Power Source
-		"Temperatura spavanja. <C>",    //Sleep Temp
-		"Vrijeme spavanja. <Minute/Sekunde>",    //Sleep Timeout
-		"Vrijeme gasenja. <Minutes>",    //Shutdown Time
-		"Osjetljivost prepoznavanja pokreta. <0=Ugaseno, 1=Najmanje osjetljivo, 9=Najosjetljivije>",    //Motion Sensitivity
-		"Jedinica temperature. <C=Celzij, F=Fahrenheit>",    //Temp Unit
-		"Prikazivanje detaljnih informacija manjim fontom tijekom cekanja.",    //Detailed Information
-		"Orijentacija ekrana. <A=Automatski, L=Ljevoruki, D=Desnoruki>",    //Orientation
-		"Prednji gumb prilikom lemljenja aktivira pojacani (Boost) nacin.",    //Boost enable
-		"Temperatura u pojacanom (Boost) nacinu.",    //Boost Temp
-		"Nacin u kojemu se lemilica pokrece po ukljucivanju napajanja. <+=Lemljenje, S=Spavanje, -=Ugaseno>",    //Auto start
-		"Bljeskanje temperature prilikom hladjenja, ako je lemilica vruca.",    //Cooling Blink
-		"Kalibriranje temperature vrha.",    //Calibrate Tip
-		"Vracanje svih postavki.",    //Reset Settings
-		"Kalibracija ulaznog napona. Podesavanje gumbima, dugacki pritisak za kraj.",    //VIN Cal
-		"Prikazivanje detaljnih informacija tijekom lemljenja.",    //ADV SLD
-		};
+    // These are all the help text for all the settings.
+    // No requirements on spacing or length.
+    /* Power source (DC or batt)          */ "Izvor napajanja. Postavlja napon iskljucivanja. <DC 10V> <S 3.3V po celiji>",
+    /* Sleep temperature                  */ "Temperatura spavanja. <C>",
+    /* Sleep timeout                      */ "Vrijeme spavanja. <Minute/Sekunde>",
+    /* Shutdown timeout                   */ "Vrijeme gasenja. <Minutes>",
+    /* Motion sensitivity level           */ "Osjetljivost prepoznavanja pokreta. <0=Ugaseno, 1=Najmanje osjetljivo, 9=Najosjetljivije>",
+    /* Temperature in F and C             */ "Jedinica temperature. <C=Celzij, F=Fahrenheit>",
+    /* Advanced idle display mode enabled */ "Prikazivanje detaljnih informacija manjim fontom tijekom cekanja.",
+    /* Display rotation mode              */ "Orijentacija ekrana. <A=Automatski, L=Ljevoruki, D=Desnoruki>",
+    /* Boost enabled                      */ "Prednji gumb prilikom lemljenja aktivira pojacani (Boost) nacin.",
+    /* Boost temperature                  */ "Temperatura u pojacanom (Boost) nacinu.",
+    /* Automatic start mode               */ "Nacin u kojemu se lemilica pokrece po ukljucivanju napajanja. <+=Lemljenje, S=Spavanje, -=Ugaseno>",
+    /* Cooldown blink                     */ "Bljeskanje temperature prilikom hladjenja, ako je lemilica vruca.",
+    /* Temperature calibration enter menu */ "Kalibriranje temperature vrha.",
+    /* Settings reset command             */ "Vracanje svih postavki.",
+    /* Calibrate input voltage            */ "Kalibracija ulaznog napona. Podesavanje gumbima, dugacki pritisak za kraj.",
+    /* Advanced soldering screen enabled  */ "Prikazivanje detaljnih informacija tijekom lemljenja.",
+};
 
 const char* SettingsCalibrationWarning = "Provjerite da je vrh ohladjen na sobnu temperaturu prije nego sto nastavite!";
 const char* UVLOWarningString = "NAPON!!!";    //Fixed width 8 chars

--- a/workspace/TS100/src/gui.cpp
+++ b/workspace/TS100/src/gui.cpp
@@ -64,95 +64,142 @@ const menuitem settingsMenu[] = { /*Struct used for all settings options in the 
 { NULL, { NULL }, { NULL } }    //end of menu marker. DO NOT REMOVE
 };
 
+
+/**
+ * Prints two small lines of short description
+ * and prepares cursor in big font after it.
+ * @param shortDescIndex Index to of short description.
+ * @param cursorCharPosition Custom cursor char position to set after printing description.
+ */
+static void printShortDescription(uint32_t shortDescIndex, uint16_t cursorCharPosition) {
+  lcd.setFont(1);
+  lcd.setCharCursor(0, 0);
+  lcd.print(SettingsShortNames[shortDescIndex][0]);
+  lcd.setCharCursor(0, 1);
+  lcd.print(SettingsShortNames[shortDescIndex][1]);
+
+  lcd.setFont(0);
+  lcd.setCharCursor(cursorCharPosition, 0);
+}
+
+
 static void settings_setInputVRange(void) {
 	systemSettings.cutoutSetting = (systemSettings.cutoutSetting + 1) % 5;
 }
+
 static void settings_displayInputVRange(void) {
-	lcd.print(SettingsShortNames[0]);
-	if (systemSettings.cutoutSetting) {
-		lcd.drawChar('0' + 2 + systemSettings.cutoutSetting);
-		lcd.drawChar('S');
-	} else {
-		lcd.print("DC");
-	}
+  printShortDescription(0, 6);
+
+  if (systemSettings.cutoutSetting) {
+    lcd.drawChar('0' + 2 + systemSettings.cutoutSetting);
+    lcd.drawChar('S');
+  }
+  else {
+    lcd.print("DC");
+  }
 }
+
 
 static void settings_setSleepTemp(void) {
 	systemSettings.SleepTemp += 10;
 	if (systemSettings.SleepTemp > 300)
 		systemSettings.SleepTemp = 50;
 }
+
 static void settings_displaySleepTemp(void) {
-	lcd.print(SettingsShortNames[1]);
+  printShortDescription(1, 5);
 	lcd.printNumber(systemSettings.SleepTemp, 3);
 }
+
+
 static void settings_setSleepTime(void) {
-	++systemSettings.SleepTime;    //Go up 1 minute at a time
-	if (systemSettings.SleepTime >= 16)
-		systemSettings.SleepTime = 1;    //can't set time over 10 mins
-//Remember that ^ is the time of no movement
+	systemSettings.SleepTime++;             //Go up 1 minute at a time
+	if (systemSettings.SleepTime >= 16) {
+	  systemSettings.SleepTime = 1;         //can't set time over 10 mins
+	}
+	//Remember that ^ is the time of no movement
 }
+
 static void settings_displaySleepTime(void) {
-	lcd.print(SettingsShortNames[2]);
-	if (systemSettings.SleepTime < 6) {
+  printShortDescription(2, 5);
+
+  if (systemSettings.SleepTime < 6) {
 		lcd.printNumber(systemSettings.SleepTime * 10, 2);
 		lcd.drawChar('S');
-	} else {
+	}
+  else {
 		lcd.printNumber(systemSettings.SleepTime - 5, 2);
 		lcd.drawChar('M');
 	}
 }
+
+
 static void settings_setShutdownTime(void) {
-	++systemSettings.ShutdownTime;
-	if (systemSettings.ShutdownTime > 60)
-		systemSettings.ShutdownTime = 0;    //wrap to off
+	systemSettings.ShutdownTime++;
+	if (systemSettings.ShutdownTime > 60) {
+	  systemSettings.ShutdownTime = 0;    //wrap to off
+	}
 }
+
 static void settings_displayShutdownTime(void) {
-	lcd.print(SettingsShortNames[3]);
+  printShortDescription(3, 6);
 	lcd.printNumber(systemSettings.ShutdownTime, 2);
 }
+
 
 static void settings_setTempF(void) {
 	systemSettings.temperatureInF = !systemSettings.temperatureInF;
 }
-static void settings_displayTempF(void) {
-	lcd.print(SettingsShortNames[5]);
 
-	if (systemSettings.temperatureInF)
-		lcd.drawChar('F');
-	else
-		lcd.drawChar('C');
+static void settings_displayTempF(void) {
+  printShortDescription(5, 7);
+
+  lcd.drawChar(
+      (systemSettings.temperatureInF)
+      ? 'F'
+      : 'C'
+  );
 }
+
 
 static void settings_setSensitivity(void) {
 	systemSettings.sensitivity++;
 	systemSettings.sensitivity = systemSettings.sensitivity % 10;
 }
+
 static void settings_displaySensitivity(void) {
-	lcd.print(SettingsShortNames[4]);
+  printShortDescription(4, 7);
 	lcd.printNumber(systemSettings.sensitivity, 1);
 }
+
 
 static void settings_setAdvancedSolderingScreens(void) {
 	systemSettings.detailedSoldering = !systemSettings.detailedSoldering;
 }
+
 static void settings_displayAdvancedSolderingScreens(void) {
-	lcd.print(SettingsShortNames[15]);
-	if (systemSettings.detailedSoldering)
-		lcd.drawChar(SettingTrueChar);
-	else
-		lcd.drawChar(SettingFalseChar);
+  printShortDescription(15, 7);
+
+  lcd.drawChar(
+      (systemSettings.detailedSoldering)
+      ? SettingTrueChar
+      : SettingFalseChar
+  );
 }
+
 
 static void settings_setAdvancedIDLEScreens(void) {
 	systemSettings.detailedIDLE = !systemSettings.detailedIDLE;
 }
+
 static void settings_displayAdvancedIDLEScreens(void) {
-	lcd.print(SettingsShortNames[6]);
-	if (systemSettings.detailedIDLE)
-		lcd.drawChar(SettingTrueChar);
-	else
-		lcd.drawChar(SettingFalseChar);
+  printShortDescription(6, 7);
+
+  lcd.drawChar(
+      (systemSettings.detailedIDLE)
+      ? SettingTrueChar
+      : SettingFalseChar
+  );
 }
 
 
@@ -160,9 +207,11 @@ static void settings_setDisplayRotation(void) {
 	systemSettings.OrientationMode++;
 	systemSettings.OrientationMode = systemSettings.OrientationMode % 3;
 }
+
 static void settings_displayDisplayRotation(void) {
-	lcd.print(SettingsShortNames[7]);
-	switch (systemSettings.OrientationMode) {
+  printShortDescription(7, 7);
+
+  switch (systemSettings.OrientationMode) {
 		case 0:
 			lcd.drawChar(SettingRightChar);
 			break;
@@ -173,66 +222,87 @@ static void settings_displayDisplayRotation(void) {
 			lcd.drawChar(SettingAutoChar);
 			break;
 	}
-
 }
+
+
 static void settings_setBoostModeEnabled(void) {
 	systemSettings.boostModeEnabled = !systemSettings.boostModeEnabled;
 }
+
 static void settings_displayBoostModeEnabled(void) {
-	lcd.print(SettingsShortNames[8]);
-	if (systemSettings.boostModeEnabled)
-		lcd.drawChar(SettingTrueChar);
-	else
-		lcd.drawChar(SettingFalseChar);
+  printShortDescription(8, 7);
+
+  lcd.drawChar(
+      (systemSettings.boostModeEnabled)
+      ? SettingTrueChar
+      : SettingFalseChar
+  );
 }
+
+
 static void settings_setBoostTemp(void) {
-	systemSettings.BoostTemp += 10;    //Go up 10 at a time
+	systemSettings.BoostTemp += 10;         //Go up 10 at a time
 	if (systemSettings.temperatureInF) {
-		if (systemSettings.BoostTemp > 850)
-			systemSettings.BoostTemp = 480;    //loop back at 250
-	} else {
-		if (systemSettings.BoostTemp > 450)
-			systemSettings.BoostTemp = 250;    //loop back at 250
+		if (systemSettings.BoostTemp > 850) {
+		  systemSettings.BoostTemp = 480;     //loop back at 250
+		}
+	}
+	else {
+		if (systemSettings.BoostTemp > 450) {
+		  systemSettings.BoostTemp = 250;     //loop back at 250
+		}
 	}
 }
+
 static void settings_displayBoostTemp(void) {
-	lcd.print(SettingsShortNames[9]);
+  printShortDescription(9, 5);
 	lcd.printNumber(systemSettings.BoostTemp, 3);
 }
+
+
 static void settings_setAutomaticStartMode(void) {
 	systemSettings.autoStartMode++;
 	systemSettings.autoStartMode %= 2;
 }
+
 static void settings_displayAutomaticStartMode(void) {
-	lcd.print(SettingsShortNames[10]);
-	switch (systemSettings.autoStartMode) {
-		case 0:
-			lcd.drawChar(SettingFalseChar);
-			break;
-		case 1:
-			lcd.drawChar(SettingTrueChar);
-			break;
-	}
+  printShortDescription(10, 7);
+
+  lcd.drawChar(
+      (systemSettings.autoStartMode)
+      ? SettingTrueChar
+      : SettingFalseChar
+  );
 }
+
+
 static void settings_setCoolingBlinkEnabled(void) {
 	systemSettings.coolingTempBlink = !systemSettings.coolingTempBlink;
 }
+
 static void settings_displayCoolingBlinkEnabled(void) {
-	lcd.print(SettingsShortNames[11]);
-	if (systemSettings.coolingTempBlink)
-		lcd.drawChar(SettingTrueChar);
-	else
-		lcd.drawChar(SettingFalseChar);
+  printShortDescription(11, 7);
+
+  lcd.drawChar(
+      (systemSettings.coolingTempBlink)
+      ? SettingTrueChar
+      : SettingFalseChar
+  );
 }
+
+
 static void settings_setResetSettings(void) {
 	settingsResetRequest = !settingsResetRequest;
 }
+
 static void settings_displayResetSettings(void) {
-	lcd.print(SettingsShortNames[13]);
-	if (settingsResetRequest)
-		lcd.drawChar(SettingTrueChar);
-	else
-		lcd.drawChar(SettingFalseChar);
+  printShortDescription(13, 7);
+
+  lcd.drawChar(
+      (settingsResetRequest)
+      ? SettingTrueChar
+      : SettingFalseChar
+  );
 }
 
 static void settings_setCalibrate(void) {
@@ -240,16 +310,18 @@ static void settings_setCalibrate(void) {
 	//We split off here to confirm with the user
 	uint8_t maxOffset = strlen(SettingsCalibrationWarning) + 5;
 	uint32_t descriptionStart = HAL_GetTick();
+
 	lcd.setFont(0);
 	lcd.clearScreen();
 	lcd.setCursor(0, 0);
-	for (;;) {
 
+	for (;;) {
 		int16_t descriptionOffset = (((HAL_GetTick() - descriptionStart) / 150) % maxOffset);
+
 		lcd.setCursor(12 * (7 - descriptionOffset), 0);
 		lcd.print(SettingsCalibrationWarning);
-		ButtonState buttons = getButtonState();
 
+		ButtonState buttons = getButtonState();
 		switch (buttons) {
 			case BUTTON_F_SHORT: {
 				//User confirmed
@@ -258,12 +330,14 @@ static void settings_setCalibrate(void) {
 				lcd.setCursor(0, 0);
 				lcd.print(".....");
 				lcd.refresh();
-				setCalibrationOffset(0);				//turn off the current offset
+
+				setCalibrationOffset(0);				    //turn off the current offset
 				for (uint8_t i = 0; i < 20; i++) {
-					getTipRawTemp(1);				//cycle through the filter a fair bit to ensure were stable.
+					getTipRawTemp(1);				          //cycle through the filter a fair bit to ensure we're stable.
 					osDelay(20);
 				}
 				osDelay(100);
+
 				uint16_t rawTempC = tipMeasurementToC(getTipRawTemp(0));
 				//We now measure the current reported tip temperature
 				uint16_t handleTempC = getHandleTemperature() / 10;
@@ -274,30 +348,33 @@ static void settings_setCalibrate(void) {
 				osDelay(100);
 				return;
 			}
-				break;
+
 			case BUTTON_BOTH:
 			case BUTTON_B_SHORT:
 			case BUTTON_F_LONG:
 			case BUTTON_B_LONG:
 				return;
-				break;
+
 			case BUTTON_NONE:
 				break;
 		}
+
 		lcd.refresh();
 		osDelay(50);
 	}
+}
 
-}
 static void settings_displayCalibrate(void) {
-	lcd.print(SettingsShortNames[12]);
+  printShortDescription(12, 5);
 }
+
 
 static void settings_setCalibrateVIN(void) {
-//Jump to the voltage calibration subscreen
+  //Jump to the voltage calibration subscreen
 	lcd.setFont(0);
 	lcd.clearScreen();
 	lcd.setCursor(0, 0);
+
 	for (;;) {
 		lcd.setCursor(0, 0);
 		lcd.printNumber(getInputVoltageX10(systemSettings.voltageDiv) / 10, 2);
@@ -310,30 +387,34 @@ static void settings_setCalibrateVIN(void) {
 			case BUTTON_F_SHORT:
 				systemSettings.voltageDiv++;
 				break;
+
 			case BUTTON_B_SHORT:
 				systemSettings.voltageDiv--;
 				break;
+
 			case BUTTON_BOTH:
 			case BUTTON_F_LONG:
 			case BUTTON_B_LONG:
 				saveSettings();
 				return;
-				break;
+
 			case BUTTON_NONE:
 				break;
 		}
+
 		lcd.refresh();
 		osDelay(50);
-		if (systemSettings.voltageDiv < 90)
-			systemSettings.voltageDiv = 90;
-		else if (systemSettings.voltageDiv > 130)
-			systemSettings.voltageDiv = 130;
+
 		//Cap to sensible values
+		if (systemSettings.voltageDiv < 90) {
+		  systemSettings.voltageDiv = 90;
+		}
+		else if (systemSettings.voltageDiv > 130) {
+		  systemSettings.voltageDiv = 130;
+		}
 	}
 }
-static void settings_displayCalibrateVIN(void) {
-	lcd.clearScreen();
-	lcd.setCursor(0, 0);
-	lcd.print(SettingsShortNames[14]);
 
+static void settings_displayCalibrateVIN(void) {
+  printShortDescription(14, 5);
 }

--- a/workspace/TS100/src/gui.cpp
+++ b/workspace/TS100/src/gui.cpp
@@ -65,6 +65,20 @@ const menuitem settingsMenu[] = { /*Struct used for all settings options in the 
 };
 
 
+static void printShortDescriptionSingleLine(uint32_t shortDescIndex) {
+  lcd.setFont(0);
+  lcd.setCharCursor(0, 0);
+  lcd.print(SettingsShortNames[shortDescIndex][0]);
+}
+
+static void printShortDescriptionDoubleLine(uint32_t shortDescIndex) {
+  lcd.setFont(1);
+  lcd.setCharCursor(0, 0);
+  lcd.print(SettingsShortNames[shortDescIndex][0]);
+  lcd.setCharCursor(0, 1);
+  lcd.print(SettingsShortNames[shortDescIndex][1]);
+}
+
 /**
  * Prints two small lines of short description
  * and prepares cursor in big font after it.
@@ -72,12 +86,15 @@ const menuitem settingsMenu[] = { /*Struct used for all settings options in the 
  * @param cursorCharPosition Custom cursor char position to set after printing description.
  */
 static void printShortDescription(uint32_t shortDescIndex, uint16_t cursorCharPosition) {
-  lcd.setFont(1);
-  lcd.setCharCursor(0, 0);
-  lcd.print(SettingsShortNames[shortDescIndex][0]);
-  lcd.setCharCursor(0, 1);
-  lcd.print(SettingsShortNames[shortDescIndex][1]);
+  //print short description (default single line, explicit double line)
+  if(SettingsShortNameType == SHORT_NAME_DOUBLE_LINE) {
+    printShortDescriptionDoubleLine(shortDescIndex);
+  }
+  else {
+    printShortDescriptionSingleLine(shortDescIndex);
+  }
 
+  //prepare cursor for value
   lcd.setFont(0);
   lcd.setCharCursor(cursorCharPosition, 0);
 }


### PR DESCRIPTION
Currently menu options are presented with a key made of 5-7 characters. For me this is often very confusing and I am forced to wait for long description even if I know what I want to change.

I think much better user experience is when 2 lines of smaller text is used. This allows to use more characters to make more readable and understandable option keys.

Here is how it looks like:
![20171203_210647](https://user-images.githubusercontent.com/6730275/33529405-d47ab924-d870-11e7-9935-c36a600b880d.jpg)
![20171203_210652](https://user-images.githubusercontent.com/6730275/33529406-d4999312-d870-11e7-9942-f478a7c0165c.jpg)
![20171203_210657](https://user-images.githubusercontent.com/6730275/33529407-d4b852fc-d870-11e7-9210-16b63aa0e5b2.jpg)
![20171203_210703](https://user-images.githubusercontent.com/6730275/33529408-d4d753b4-d870-11e7-87e7-df750bda142f.jpg)
![20171203_210715](https://user-images.githubusercontent.com/6730275/33529409-d4f3f5c8-d870-11e7-8533-da89f711cc81.jpg)