### PR TITLE
Changed starting address for saving the device settings in flash.

### DIFF
--- a/workspace/TS100/src/Settings.cpp
+++ b/workspace/TS100/src/Settings.cpp
@@ -9,7 +9,7 @@
 
 #include "Settings.h"
 #include "Setup.h"
-#define FLASH_ADDR 		(0x8000000|0xBC00)/*Flash start OR'ed with the maximum amount of flash - 1024 bytes*/
+#define FLASH_ADDR 		(0x8000000|0xFC00)/*Flash start OR'ed with the maximum amount of flash - 1024 bytes*/
 #include "string.h"
 systemSettingsType systemSettings;
 


### PR DESCRIPTION
According to the linker script the settings should go on the last
available page of the devices flash rom. This should be page 63
starting at 0x800fc00.