### PR TITLE
 Add Fahrenheit management for SleepTemp && Improve swithing °C -> °F

### DIFF
--- a/workspace/TS100/inc/OLED.hpp
+++ b/workspace/TS100/inc/OLED.hpp
@@ -42,6 +42,7 @@ public:
 	void clearScreen();						// Clears the buffer
 	void drawBattery(uint8_t state);		// Draws the battery level symbol
 	void drawCheckbox(bool state);		// Draws a checkbox
+	void drawTemperatureSymbol(bool inFahrenheit); // Draw Temperature symbol
 	void drawSymbol(uint8_t symbolID);//Used for drawing symbols of a predictable width
 	void drawArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
 			const uint8_t* ptr);

--- a/workspace/TS100/src/OLED.cpp
+++ b/workspace/TS100/src/OLED.cpp
@@ -275,6 +275,9 @@ void OLED::drawBattery(uint8_t state) {
 void OLED::drawCheckbox(bool state) {
 	drawSymbol((state) ? 17 : 18);
 }
+void OLED::drawTemperatureSymbol(bool inFahrenheit) {
+	drawSymbol((inFahrenheit) ? 0 : 1);
+}
 void OLED::drawSymbol(uint8_t symbolID) {
 	//draw a symbol to the current cursor location
 	setFont(2);

--- a/workspace/TS100/src/gui.cpp
+++ b/workspace/TS100/src/gui.cpp
@@ -185,8 +185,17 @@ static void settings_displayInputVRange(void) {
 
 
 static void settings_setSleepTemp(void) {
-  systemSettings.SleepTemp += 10;
-  if (systemSettings.SleepTemp > 300) systemSettings.SleepTemp = 50;
+  if (systemSettings.temperatureInF) {
+	  systemSettings.SleepTemp += 20;
+      if (systemSettings.SleepTemp < 120 || systemSettings.SleepTemp > 580) {
+        systemSettings.SleepTemp = 120;  // loop back at 120
+      }
+  } else {
+	  systemSettings.SleepTemp += 10;
+      if (systemSettings.SleepTemp < 50 || systemSettings.SleepTemp > 300) {
+        systemSettings.SleepTemp = 50;  // loop back at 250
+      }
+  }
 }
 
 static void settings_displaySleepTemp(void) {
@@ -310,13 +319,14 @@ static void settings_displayBoostModeEnabled(void) {
 
 
 static void settings_setBoostTemp(void) {
-  systemSettings.BoostTemp += 10;  // Go up 10 at a time
   if (systemSettings.temperatureInF) {
-    if (systemSettings.BoostTemp > 850) {
-      systemSettings.BoostTemp = 480;  // loop back at 250
+	systemSettings.BoostTemp += 20;  // Go up 20 at a time
+	if (systemSettings.BoostTemp < 480 || systemSettings.BoostTemp > 840) {
+      systemSettings.BoostTemp = 480;  // loop back at 480
     }
   } else {
-    if (systemSettings.BoostTemp > 450) {
+	systemSettings.BoostTemp += 10;  // Go up 10 at a time
+    if (systemSettings.BoostTemp < 250 || systemSettings.BoostTemp > 450) {
       systemSettings.BoostTemp = 250;  // loop back at 250
     }
   }

--- a/workspace/TS100/src/gui.cpp
+++ b/workspace/TS100/src/gui.cpp
@@ -245,7 +245,7 @@ static void settings_setTempF(void) {
 static void settings_displayTempF(void) {
   printShortDescription(5, 7);
 
-  lcd.drawChar((systemSettings.temperatureInF) ? 'F' : 'C');
+  lcd.drawTemperatureSymbol(systemSettings.temperatureInF);
 }
 
 

--- a/workspace/TS100/src/main.cpp
+++ b/workspace/TS100/src/main.cpp
@@ -92,6 +92,7 @@ void gui_drawTipTemp() {
   //	Temp = systemSettings.SolderingTemp;
 
   lcd.printNumber(Temp, 3);  // Draw the tip temp out finally
+  lcd.drawTemperatureSymbol(systemSettings.temperatureInF);
 }
 ButtonState getButtonState() {
   /*
@@ -274,8 +275,8 @@ static void gui_solderingTempAdjust() {
     }
     // constrain between 50-450 C
     if (systemSettings.temperatureInF) {
-      if (systemSettings.SolderingTemp > 850)
-        systemSettings.SolderingTemp = 850;
+      if (systemSettings.SolderingTemp > 840)
+        systemSettings.SolderingTemp = 840;
     } else {
       if (systemSettings.SolderingTemp > 450)
         systemSettings.SolderingTemp = 450;
@@ -564,13 +565,8 @@ static void gui_solderingMode() {
         gui_drawBatteryIcon();
 
         lcd.drawChar(' ');  // Space out gap between battery <-> temp
-        if (systemSettings.temperatureInF) {
-          gui_drawTipTemp();  // Draw current tip temp
-          lcd.drawSymbol(0);  // deg F
-        } else {
-          gui_drawTipTemp();  // Draw current tip temp
-          lcd.drawSymbol(1);  // deg C
-        }
+
+        gui_drawTipTemp();  // Draw current tip temp
 
         // We draw boost arrow if boosting, or else gap temp <-> heat indicator
         if (boostModeOn)
@@ -597,13 +593,7 @@ static void gui_solderingMode() {
         else
           lcd.drawChar(' ');
 
-        if (systemSettings.temperatureInF) {
-          gui_drawTipTemp();  // Draw current tip temp
-          lcd.drawSymbol(0);  // deg F
-        } else {
-          gui_drawTipTemp();  // Draw current tip temp
-          lcd.drawSymbol(1);  // deg C
-        }
+        gui_drawTipTemp();  // Draw current tip temp
 
         lcd.drawChar(' ');  // Space out gap between battery <-> temp
 


### PR DESCRIPTION
**Add Fahrenheit management for SleepTemp && Improve swithing °C -> °F**
- Change step from 10 to 20 for fahrenheit (quite same step number to
make a loop in °C or °F). It was really long too make the loop before
- Create a check for min temperature. When switching from °C -> °F
temperatures in memory stay in °C so they can be too low

**Refactoring Fahrenheit or Celsius symbol display**


TODO : Convert temperature in memory (SleepTemp & BoostTemp) when unit
is switched or reset temperatures to specific default value, to avoid
bugs when soldering. If I choose 840°F for boost mode then I switch to °C, what happen when I start boost mode for 840°C ????