### PR TITLE
Menu factory reset last

### DIFF
--- a/workspace/TS100/src/Translation.c
+++ b/workspace/TS100/src/Translation.c
@@ -98,7 +98,7 @@ const char* SettingsShortNames[16][2] = {
   /* (<= 13) Automatic start mode               */ {"Auto", "start"},
   /* (<= 13) Cooldown blink                     */ {"Cooldown", "blink"},
   /* (<= 16) Temperature calibration enter menu */ {"Calibrate", "temperature?"},
-  /* (<= 16) Settings reset command             */ {"Factory", "Reset?"},
+  /* (<= 16) Settings reset command             */ {"Factory", "reset?"},
   /* (<= 16) Calibrate input voltage            */ {"Calibrate", "input voltage?"},
   /* (<= 13) Advanced soldering screen enabled  */ {"Detailed", "solder screen"},
 };

--- a/workspace/TS100/src/gui.cpp
+++ b/workspace/TS100/src/gui.cpp
@@ -46,54 +46,23 @@ static void settings_displayCalibrateVIN(void);
 
 const menuitem settingsMenu[] = {
     /*Struct used for all settings options in the settings menu*/
-    {(const char*)SettingsLongNames[0],
-     {settings_setInputVRange},
-     {settings_displayInputVRange}}, /*Voltage input*/
-    {(const char*)SettingsLongNames[1],
-     {settings_setSleepTemp},
-     {settings_displaySleepTemp}}, /*Sleep Temp*/
-    {(const char*)SettingsLongNames[2],
-     {settings_setSleepTime},
-     {settings_displaySleepTime}}, /*Sleep Time*/
-    {(const char*)SettingsLongNames[3],
-     {settings_setShutdownTime},
-     {settings_displayShutdownTime}}, /*Shutdown Time*/
-    {(const char*)SettingsLongNames[4],
-     {settings_setSensitivity},
-     {settings_displaySensitivity}}, /* Motion Sensitivity*/
-    {(const char*)SettingsLongNames[5],
-     {settings_setTempF},
-     {settings_displayTempF}}, /* Motion Sensitivity*/
-    {(const char*)SettingsLongNames[6],
-     {settings_setAdvancedIDLEScreens},
-     {settings_displayAdvancedIDLEScreens}}, /* Advanced screens*/
-    {(const char*)SettingsLongNames[15],
-     {settings_setAdvancedSolderingScreens},
-     {settings_displayAdvancedSolderingScreens}}, /* Advanced screens*/
-    {(const char*)SettingsLongNames[7],
-     {settings_setDisplayRotation},
-     {settings_displayDisplayRotation}}, /*Display Rotation*/
-    {(const char*)SettingsLongNames[8],
-     {settings_setBoostModeEnabled},
-     {settings_displayBoostModeEnabled}}, /*Enable Boost*/
-    {(const char*)SettingsLongNames[9],
-     {settings_setBoostTemp},
-     {settings_displayBoostTemp}}, /*Boost Temp*/
-    {(const char*)SettingsLongNames[10],
-     {settings_setAutomaticStartMode},
-     {settings_displayAutomaticStartMode}}, /*Auto start*/
-    {(const char*)SettingsLongNames[11],
-     {settings_setCoolingBlinkEnabled},
-     {settings_displayCoolingBlinkEnabled}}, /*Cooling blink warning*/
-    {(const char*)SettingsLongNames[12],
-     {settings_setCalibrate},
-     {settings_displayCalibrate}}, /*Calibrate tip*/
-    {(const char*)SettingsLongNames[13],
-     {settings_setResetSettings},
-     {settings_displayResetSettings}}, /*Resets settings*/
-    {(const char*)SettingsLongNames[14],
-     {settings_setCalibrateVIN},
-     {settings_displayCalibrateVIN}}, /*Voltage input cal*/
+    {(const char*)SettingsLongNames[0], {settings_setInputVRange}, {settings_displayInputVRange}}, /*Voltage input*/
+    {(const char*)SettingsLongNames[1], {settings_setSleepTemp}, {settings_displaySleepTemp}}, /*Sleep Temp*/
+    {(const char*)SettingsLongNames[2], {settings_setSleepTime}, {settings_displaySleepTime}}, /*Sleep Time*/
+    {(const char*)SettingsLongNames[3], {settings_setShutdownTime}, {settings_displayShutdownTime}}, /*Shutdown Time*/
+    {(const char*)SettingsLongNames[4], {settings_setSensitivity}, {settings_displaySensitivity}}, /* Motion Sensitivity*/
+    {(const char*)SettingsLongNames[5], {settings_setTempF}, {settings_displayTempF}}, /* Motion Sensitivity*/
+    {(const char*)SettingsLongNames[6], {settings_setAdvancedIDLEScreens}, {settings_displayAdvancedIDLEScreens}}, /* Advanced screens*/
+    {(const char*)SettingsLongNames[15], {settings_setAdvancedSolderingScreens}, {settings_displayAdvancedSolderingScreens}}, /* Advanced screens*/
+    {(const char*)SettingsLongNames[7], {settings_setDisplayRotation}, {settings_displayDisplayRotation}}, /*Display Rotation*/
+    {(const char*)SettingsLongNames[8], {settings_setBoostModeEnabled}, {settings_displayBoostModeEnabled}}, /*Enable Boost*/
+    {(const char*)SettingsLongNames[9], {settings_setBoostTemp}, {settings_displayBoostTemp}}, /*Boost Temp*/
+    {(const char*)SettingsLongNames[10], {settings_setAutomaticStartMode}, {settings_displayAutomaticStartMode}}, /*Auto start*/
+    {(const char*)SettingsLongNames[11], {settings_setCoolingBlinkEnabled}, {settings_displayCoolingBlinkEnabled}}, /*Cooling blink warning*/
+    {(const char*)SettingsLongNames[12], {settings_setCalibrate}, {settings_displayCalibrate}}, /*Calibrate tip*/
+    {(const char*)SettingsLongNames[14], {settings_setCalibrateVIN}, {settings_displayCalibrateVIN}}, /*Voltage input cal*/
+    //reset is last menu item
+    {(const char*)SettingsLongNames[13], {settings_setResetSettings}, {settings_displayResetSettings}}, /*Resets settings*/
     {NULL, {NULL}, {NULL}}            // end of menu marker. DO NOT REMOVE
 };
 


### PR DESCRIPTION
This puts `Factory reset` as the last menu option as commonly used in device menus.