### PR TITLE
Croatian Language: Double-line menus + some minor translation corrections

### DIFF
--- a/workspace/TS100/inc/Translation.h
+++ b/workspace/TS100/inc/Translation.h
@@ -22,10 +22,19 @@ extern const char* SettingsLongNames[16];
 extern const char* SettingsCalibrationWarning;
 extern const char* SettingsResetWarning;
 extern const char* UVLOWarningString;
+extern const char* UndervoltageString;
+extern const char* InputVoltageString;
+extern const char* WarningTipTempString;
+extern const char* BadTipString;
+
 extern const char* SleepingSimpleString;
 extern const char* SleepingAdvancedString;
 extern const char* WarningSimpleString;
 extern const char* WarningAdvancedString;
+extern const char* SleepingTipAdvancedString;
+extern const char* IdleTipString;
+extern const char* IdleSetString;
+extern const char* TipDisconnectedString;
 
 extern const char SettingTrueChar;
 extern const char SettingFalseChar;

--- a/workspace/TS100/src/Translation.c
+++ b/workspace/TS100/src/Translation.c
@@ -555,53 +555,53 @@ const char* SettingsLongNames[16] = {
 	// These are all the help text for all the settings.
 	// No requirements on spacing or length.
 	/* Power source (DC or batt)          */ "Izvor napajanja. Postavlja napon isključivanja. <DC 10V> <S 3.3V po ćeliji>",
-	/* Sleep temperature                  */ "Temperatura spavanja. <C>",
+	/* Sleep temperature                  */ "Temperatura spavanja.",
 	/* Sleep timeout                      */ "Vrijeme spavanja. <Minute/Sekunde>",
-	/* Shutdown timeout                   */ "Vrijeme gašenja. <Minutes>",
+	/* Shutdown timeout                   */ "Vrijeme gašenja. <Minute>",
 	/* Motion sensitivity level           */ "Osjetljivost prepoznavanja pokreta. <0=Ugašeno, 1=Najmanje osjetljivo, 9=Najosjetljivije>",
 	/* Temperature in F and C             */ "Jedinica temperature. <C=Celzij, F=Fahrenheit>",
 	/* Advanced idle display mode enabled */ "Prikazivanje detaljnih informacija manjim fontom tijekom čekanja.",
 	/* Display rotation mode              */ "Orijentacija ekrana. <A=Automatski, L=Ljevoruki, D=Desnoruki>",
-	/* Boost enabled                      */ "Držanjem prednjeg gumba prilikom lemljenja aktivira se pojačani (Boost) način.",
-	/* Boost temperature                  */ "Temperatura u pojačanom (Boost) načinu.",
-	/* Automatic start mode               */ "Početno stanje lemilice po uključivanju napajanja. <+=Lemljenje, S=Spavanje, -=Ugašeno>",
-	/* Cooldown blink                     */ "Bljeskanje temperature prilikom hlađenja, ako je lemilica vruća.",
-	/* Temperature calibration enter menu */ "Kalibriranje temperature mjeri razliku temperature vška i temperature drške, dok je lemilica hladna.",
+	/* Boost enabled                      */ "Držanjem prednjeg gumba prilikom lemljenja aktivira se pojačani način.",
+	/* Boost temperature                  */ "Temperatura u pojačanom načinu.",
+	/* Automatic start mode               */ "Početno stanje lemilice po uključivanju napajanja.",
+	/* Cooldown blink                     */ "Bljeskajući prikaz temperature prilikom hlađenja, ako je lemilica vruća.",
+	/* Temperature calibration enter menu */ "Pri kalibraciji se mjeri razlika očitanja temperature vrška i temperature drške, dok je lemilica hladna.",
 	/* Settings reset command             */ "Vraćanje svih postavki.",
 	/* Calibrate input voltage            */ "Kalibracija ulaznog napona. Podešavanje gumbima, dugački pritisak za kraj.",
 	/* Advanced soldering screen enabled  */ "Prikazivanje detaljnih informacija tijekom lemljenja.",
 };
 
 const char* SettingsCalibrationWarning = "Provjerite da je vršak ohlađen na sobnu temperaturu prije nego što nastavite!";
-const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
+const char* SettingsResetWarning = "Želite li vratiti sve postavke na tvorničke vrijednosti?";
 const char* UVLOWarningString = "NAPON!!!";          // Fixed width 8 chars
 const char* SleepingSimpleString = "Zzzz";           // Must be <= 4 chars
 const char* SleepingAdvancedString = "Spavanje...";  // <=17 chars
 const char* WarningSimpleString = "VRUĆ";            // Must be <= 4 chars
-const char* WarningAdvancedString = "OPREZ! Vršak je vruć!";
+const char* WarningAdvancedString = "OPREZ, VRUĆE!";
 
 const char SettingRightChar = 'D';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 
-const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_DOUBLE_LINE;
 const char* SettingsShortNames[16][2] = {
-  /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
-  /* (<= 4) Sleep temperature                  */ {"STMP"},
-  /* (<= 4) Sleep timeout                      */ {"STME"},
-  /* (<= 5) Shutdown timeout                   */ {"SHTME"},
-  /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
-  /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
-  /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
-  /* (<= 6) Display rotation mode              */ {"DSPROT"},
-  /* (<= 6) Boost enabled                      */ {"BOOST"},
-  /* (<= 4) Boost temperature                  */ {"BTMP"},
-  /* (<= 6) Automatic start mode               */ {"ASTART"},
-  /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
-  /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
-  /* (<= 8) Settings reset command             */ {"RESET?"},
-  /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
-  /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
+  /* (<= 11) Power source (DC or batt)          */ {"Izvor", "napajanja"},
+  /* (<=  9) Sleep temperature                  */ {"Temp", "spavanja"},
+  /* (<=  9) Sleep timeout                      */ {"Vrijeme", "spavanja"},
+  /* (<= 11) Shutdown timeout                   */ {"Vrijeme", "gašenja"},
+  /* (<= 13) Motion sensitivity level           */ {"Osjetljivost", "pokreta"},
+  /* (<= 13) Temperature in F and C             */ {"Jedinica", "temperature"},
+  /* (<= 13) Advanced idle display mode enabled */ {"Informacije", "kod čekanja"},
+  /* (<= 13) Display rotation mode              */ {"Orijentacija", "ekrana"},
+  /* (<= 13) Boost enabled                      */ {"Pojačani", "način"},
+  /* (<=  9) Boost temperature                  */ {"Pojačana", "temp"},
+  /* (<= 13) Automatic start mode               */ {"Automatski", "start"},
+  /* (<= 13) Cooldown blink                     */ {"Bljeskanje", "pri hlađenju"},
+  /* (<= 16) Temperature calibration enter menu */ {"Kalibracija", "temperature"},
+  /* (<= 16) Settings reset command             */ {"Tvorničke", "postavke"},
+  /* (<= 16) Calibrate input voltage            */ {"Kalibracija", "napona napajanja"},
+  /* (<= 13) Advanced soldering screen enabled  */ {"Informacije", "pri lemljenju"},
 };
 #endif
 

--- a/workspace/TS100/src/Translation.c
+++ b/workspace/TS100/src/Translation.c
@@ -73,11 +73,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Please ensure the tip is at room temperature before continuing!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "LOW VOLT";          // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Zzzz";           // Must be <= 4 chars
-const char* SleepingAdvancedString = "Sleeping...";  // <=17 chars
+const char* SleepingAdvancedString = "Sleeping...";  // <=16 chars
 const char* WarningSimpleString = "HOT!";            // Must be <= 4 chars
-const char* WarningAdvancedString = "WARNING! TIP HOT!";
+const char* WarningAdvancedString = "!!! TIP HOT !!!"; // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
@@ -128,11 +136,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Убедитесь, что жало остыло до комнатной температуры, прежде чем продолжать!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "БАТ РАЗР";          // Fixed width 8 chars
+const char* UVLOWarningString = "БАТ РАЗР";          // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Хррр";           // Must be <= 4 chars
-const char* SleepingAdvancedString = "Ожидание...";  // <=17 chars
+const char* SleepingAdvancedString = "Ожидание...";  // <=16 chars
 const char* WarningSimpleString = " АЙ!";            // Must be <= 4 chars
-const char* WarningAdvancedString = "ОСТОРОЖНО! ГОРЯЧО";
+const char* WarningAdvancedString = "ОСТОРОЖНО! ГОРЯЧО"; // <=16 chars
+cconst char* SleepingTipAdvancedString = "Tip:";     // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 /*
  * #TODO change support for multibyte constants here
@@ -189,11 +205,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Please ensure the tip is at room temperature before continuing!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "LOW VOLT";          // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Zzzz";           // Must be <= 4 chars
-const char* SleepingAdvancedString = "Sleeping...";  // <=17 chars
+const char* SleepingAdvancedString = "Sleeping...";  // <=16 chars
 const char* WarningSimpleString = "HOT!";            // Must be <= 4 chars
-const char* WarningAdvancedString = "WARNING! TIP HOT!";
+const char* WarningAdvancedString = "WARNING! TIP HOT!"; // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
@@ -244,11 +268,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Please ensure the tip is at room temperature before continuing!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "LOW VOLT";          // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Zzzz";           // Must be <= 4 chars
-const char* SleepingAdvancedString = "Sleeping...";  // <=17 chars
+const char* SleepingAdvancedString = "Sleeping...";  // <=16 chars
 const char* WarningSimpleString = "HOT!";            // Must be <= 4 chars
-const char* WarningAdvancedString = "WARNING! TIP HOT!";
+const char* WarningAdvancedString = "WARNING! TIP HOT!";  // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
@@ -299,11 +331,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Assicurati che la punta si trovi a temperatura ambiente prima di continuare!";
 const char* SettingsResetWarning = "Ripristinare le impostazioni iniziali?";
-const char* UVLOWarningString = "LOW VOLT";      // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Zzzz";       // Must be <= 4 chars
-const char* SleepingAdvancedString = "Standby";  // <=17 chars
+const char* SleepingAdvancedString = "Standby";  // <=16 chars
 const char* WarningSimpleString = "HOT!";        // Must be <= 4 chars
-const char* WarningAdvancedString = "ATTENZIONE! PUNTA CALDA!";
+const char* WarningAdvancedString = "ATTENZIONE! PUNTA CALDA!";  // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'D';
 const char SettingLeftChar = 'S';
@@ -354,11 +394,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Assurez-vous que la panne soit à température ambiante avant de continuer!";
 const char* SettingsResetWarning = "Voulez-vous vraiment réinitialiser les paramètres aux valeurs d'usine?";
-const char* UVLOWarningString = "LOW VOLT";             // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Zzzz";              // Must be <= 4 chars
-const char* SleepingAdvancedString = "En veille...";    // <=17 chars
+const char* SleepingAdvancedString = "En veille...";    // <=16 chars
 const char* WarningSimpleString = "HOT!";               // Must be <= 4 chars
 const char* WarningAdvancedString = "ATTENTION! CHAUD"; // Must be <= 16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'D';
 const char SettingLeftChar = 'G';
@@ -409,11 +457,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Vor dem Fortfahren muss die Lötspitze vollständig abgekühlt sein!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "LOW VOLT";           // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Zzz ";            // Must be <= 4 chars
-const char* SleepingAdvancedString = "Ruhemodus...";  // <=17 chars
+const char* SleepingAdvancedString = "Ruhemodus...";  // <=16 chars
 const char* WarningSimpleString = "HEIß";             // Must be <= 4 chars
-const char* WarningAdvancedString = "Achtung! Spitze Heiß!";
+const char* WarningAdvancedString = "Achtung! Spitze Heiß!"; // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
@@ -464,11 +520,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Najprv sa prosim uistite, ze hrot ma izbovu teplotu!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "LOW VOLT";               // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Chrr";                // Must be <= 4 chars
-const char* SleepingAdvancedString = "Kludovy rezim...";  // <=17 chars
+const char* SleepingAdvancedString = "Kludovy rezim...";  // <=16 chars
 const char* WarningSimpleString = "HOT!";                 // Must be <= 4 chars
-const char* WarningAdvancedString = "Pozor! Hrot je horuci!";
+const char* WarningAdvancedString = "Pozor! Hrot je horuci!";  // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
@@ -519,11 +583,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Lütfen devam etmeden önce ucun oda sıcaklığında olduğunu garantiye alın!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "LOW VOLT";        // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";          // <=8 chars
+const char* UndervoltageString = "Undervoltage";   // <=16 chars
+const char* InputVoltageString = "Input V: ";      // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";   // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";              // <=16 chars
 const char* SleepingSimpleString = "Zzzz";         // Must be <= 4 chars
-const char* SleepingAdvancedString = "Uyuyor...";  // <=17 chars
+const char* SleepingAdvancedString = "Uyuyor...";  // <=16 chars
 const char* WarningSimpleString = "HOT!";          // Must be <= 4 chars
-const char* WarningAdvancedString = "UYARI! UÇ SICAK!";
+const char* WarningAdvancedString = "UYARI! UÇ SICAK!";  // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
@@ -555,53 +627,61 @@ const char* SettingsLongNames[16] = {
 	// These are all the help text for all the settings.
 	// No requirements on spacing or length.
 	/* Power source (DC or batt)          */ "Izvor napajanja. Postavlja napon isključivanja. <DC 10V> <S 3.3V po ćeliji>",
-	/* Sleep temperature                  */ "Temperatura spavanja.",
+	/* Sleep temperature                  */ "Temperatura spavanja. <C>",
 	/* Sleep timeout                      */ "Vrijeme spavanja. <Minute/Sekunde>",
-	/* Shutdown timeout                   */ "Vrijeme gašenja. <Minute>",
+	/* Shutdown timeout                   */ "Vrijeme gašenja. <Minutes>",
 	/* Motion sensitivity level           */ "Osjetljivost prepoznavanja pokreta. <0=Ugašeno, 1=Najmanje osjetljivo, 9=Najosjetljivije>",
 	/* Temperature in F and C             */ "Jedinica temperature. <C=Celzij, F=Fahrenheit>",
 	/* Advanced idle display mode enabled */ "Prikazivanje detaljnih informacija manjim fontom tijekom čekanja.",
 	/* Display rotation mode              */ "Orijentacija ekrana. <A=Automatski, L=Ljevoruki, D=Desnoruki>",
-	/* Boost enabled                      */ "Držanjem prednjeg gumba prilikom lemljenja aktivira se pojačani način.",
-	/* Boost temperature                  */ "Temperatura u pojačanom načinu.",
-	/* Automatic start mode               */ "Početno stanje lemilice po uključivanju napajanja.",
-	/* Cooldown blink                     */ "Bljeskajući prikaz temperature prilikom hlađenja, ako je lemilica vruća.",
-	/* Temperature calibration enter menu */ "Pri kalibraciji se mjeri razlika očitanja temperature vrška i temperature drške, dok je lemilica hladna.",
+	/* Boost enabled                      */ "Držanjem prednjeg gumba prilikom lemljenja aktivira se pojačani (Boost) način.",
+	/* Boost temperature                  */ "Temperatura u pojačanom (Boost) načinu.",
+	/* Automatic start mode               */ "Početno stanje lemilice po uključivanju napajanja. <+=Lemljenje, S=Spavanje, -=Ugašeno>",
+	/* Cooldown blink                     */ "Bljeskanje temperature prilikom hlađenja, ako je lemilica vruća.",
+	/* Temperature calibration enter menu */ "Kalibriranje temperature mjeri razliku temperature vška i temperature drške, dok je lemilica hladna.",
 	/* Settings reset command             */ "Vraćanje svih postavki.",
 	/* Calibrate input voltage            */ "Kalibracija ulaznog napona. Podešavanje gumbima, dugački pritisak za kraj.",
 	/* Advanced soldering screen enabled  */ "Prikazivanje detaljnih informacija tijekom lemljenja.",
 };
 
 const char* SettingsCalibrationWarning = "Provjerite da je vršak ohlađen na sobnu temperaturu prije nego što nastavite!";
-const char* SettingsResetWarning = "Želite li vratiti sve postavke na tvorničke vrijednosti?";
-const char* UVLOWarningString = "NAPON!!!";          // Fixed width 8 chars
-const char* SleepingSimpleString = "Zzzz";           // Must be <= 4 chars
-const char* SleepingAdvancedString = "Spavanje...";  // <=17 chars
-const char* WarningSimpleString = "VRUĆ";            // Must be <= 4 chars
-const char* WarningAdvancedString = "OPREZ, VRUĆE!";
+const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
+const char* UVLOWarningString = "BATERIJA";           // <=8 chars
+const char* UndervoltageString = "PRENIZAK NAPON";    // <=16 chars
+const char* InputVoltageString = "Napajanje: ";       // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Temp vrha: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "NEISPRAVAN VRH";          // <=16 chars
+const char* SleepingSimpleString = "Zzz ";            // Must be <= 4 chars
+const char* SleepingAdvancedString = "SPAVANJE...";   // <=16 chars
+const char* WarningSimpleString = "VRUĆ";             // Must be <= 4 chars
+const char* WarningAdvancedString = "OPREZ, VRUĆE!";  // <=16 chars
+const char* SleepingTipAdvancedString = "Vrh: ";      // <=6 chars
+const char* IdleTipString = "Vrh: ";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " / ";       // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "VRH NIJE SPOJEN!"; // <=16 chars
 
 const char SettingRightChar = 'D';
 const char SettingLeftChar = 'L';
 const char SettingAutoChar = 'A';
 
-const enum ShortNameType SettingsShortNameType = SHORT_NAME_DOUBLE_LINE;
+const enum ShortNameType SettingsShortNameType = SHORT_NAME_SINGLE_LINE;
 const char* SettingsShortNames[16][2] = {
-  /* (<= 11) Power source (DC or batt)          */ {"Izvor", "napajanja"},
-  /* (<=  9) Sleep temperature                  */ {"Temp", "spavanja"},
-  /* (<=  9) Sleep timeout                      */ {"Vrijeme", "spavanja"},
-  /* (<= 11) Shutdown timeout                   */ {"Vrijeme", "gašenja"},
-  /* (<= 13) Motion sensitivity level           */ {"Osjetljivost", "pokreta"},
-  /* (<= 13) Temperature in F and C             */ {"Jedinica", "temperature"},
-  /* (<= 13) Advanced idle display mode enabled */ {"Informacije", "kod čekanja"},
-  /* (<= 13) Display rotation mode              */ {"Orijentacija", "ekrana"},
-  /* (<= 13) Boost enabled                      */ {"Pojačani", "način"},
-  /* (<=  9) Boost temperature                  */ {"Pojačana", "temp"},
-  /* (<= 13) Automatic start mode               */ {"Automatski", "start"},
-  /* (<= 13) Cooldown blink                     */ {"Bljeskanje", "pri hlađenju"},
-  /* (<= 16) Temperature calibration enter menu */ {"Kalibracija", "temperature"},
-  /* (<= 16) Settings reset command             */ {"Tvorničke", "postavke"},
-  /* (<= 16) Calibrate input voltage            */ {"Kalibracija", "napona napajanja"},
-  /* (<= 13) Advanced soldering screen enabled  */ {"Informacije", "pri lemljenju"},
+  /* (<= 5) Power source (DC or batt)          */ {"PWRSC"},
+  /* (<= 4) Sleep temperature                  */ {"STMP"},
+  /* (<= 4) Sleep timeout                      */ {"STME"},
+  /* (<= 5) Shutdown timeout                   */ {"SHTME"},
+  /* (<= 6) Motion sensitivity level           */ {"MSENSE"},
+  /* (<= 6) Temperature in F and C             */ {"TMPUNT"},
+  /* (<= 6) Advanced idle display mode enabled */ {"ADVIDL"},
+  /* (<= 6) Display rotation mode              */ {"DSPROT"},
+  /* (<= 6) Boost enabled                      */ {"BOOST"},
+  /* (<= 4) Boost temperature                  */ {"BTMP"},
+  /* (<= 6) Automatic start mode               */ {"ASTART"},
+  /* (<= 6) Cooldown blink                     */ {"CLBLNK"},
+  /* (<= 8) Temperature calibration enter menu */ {"TMP CAL?"},
+  /* (<= 8) Settings reset command             */ {"RESET?"},
+  /* (<= 8) Calibrate input voltage            */ {"CAL VIN?"},
+  /* (<= 6) Advanced soldering screen enabled  */ {"ADVSLD"},
 };
 #endif
 
@@ -629,11 +709,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Ujistěte se, že hrot má pokojovou teplotu! ";          // ending space needed
 const char* SettingsResetWarning = "Opravdu chcete resetovat zařízení do továrního nastavení?";
-const char* UVLOWarningString = "LOW VOLT";              // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Zzz ";               // Must be <= 4 chars
-const char* SleepingAdvancedString = "Režim spánku...";  // <=17 chars
+const char* SleepingAdvancedString = "Režim spánku...";  // <=16 chars
 const char* WarningSimpleString = "HOT!";                // Must be <= 4 chars
 const char* WarningAdvancedString = "!! HORKÝ HROT !!";  // <= 16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'P';
 const char SettingLeftChar = 'L';
@@ -684,11 +772,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Folytatás előtt győződj meg róla, hogy a hegy szobahőmérsékletű!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "LOW VOLT";       // Fixed width 8 chars
-const char* SleepingSimpleString = "Zzzz";        // Must be <= 4 chars
-const char* SleepingAdvancedString = "Alvás...";  // <=17 chars
-const char* WarningSimpleString = "HOT!";         // Must be <= 4 chars
-const char* WarningAdvancedString = "FIGYELEM! FORRÓ HEGY!";
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
+const char* SleepingSimpleString = "Zzzz";           // Must be <= 4 chars
+const char* SleepingAdvancedString = "Alvás...";     // <=16 chars
+const char* WarningSimpleString = "HOT!";            // Must be <= 4 chars
+const char* WarningAdvancedString = "FIGYELEM! FORRÓ HEGY!";  // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'R';
 const char SettingLeftChar = 'L';
@@ -739,11 +835,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Sørg for at loddespidsen er ved stuetemperatur, inden du fortsætter!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "Lav Volt";       // Fixed width 8 chars
+const char* UVLOWarningString = "Lav Volt";          // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Zzzz";        // Must be <= 4 chars
-const char* SleepingAdvancedString = "Dvale...";  // <=17 chars
+const char* SleepingAdvancedString = "Dvale...";  // <=16 chars
 const char* WarningSimpleString = "Varm";         // Must be <= 4 chars
-const char* WarningAdvancedString = "ADVARSEL! VARM LODDESPIDS!";
+const char* WarningAdvancedString = "ADVARSEL! VARM LODDESPIDS!"; // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'H';
 const char SettingLeftChar = 'V';
@@ -794,11 +898,19 @@ const char* SettingsLongNames[16] = {
 
 const char* SettingsCalibrationWarning = "Przed kontynuowaniem upewnij się, że końcówka osiągnela temperature pokojowa!";
 const char* SettingsResetWarning = "Are you sure to reset settings to default values?";
-const char* UVLOWarningString = "LOW VOLT";          // Fixed width 8 chars
+const char* UVLOWarningString = "DC LOW";            // <=8 chars
+const char* UndervoltageString = "Undervoltage";     // <=16 chars
+const char* InputVoltageString = "Input V: ";        // <=11 chars, preferably end with a space
+const char* WarningTipTempString = "Tip Temp: ";     // <=11 chars, preferably end with a space
+const char* BadTipString = "BAD TIP";                // <=16 chars
 const char* SleepingSimpleString = "Zzz!";           // Must be <= 4 chars
-const char* SleepingAdvancedString = "Uspienie...";  // <=17 chars
+const char* SleepingAdvancedString = "Uspienie...";  // <=16 chars
 const char* WarningSimpleString = "HOT!";            // Must be <= 4 chars
-const char* WarningAdvancedString = "UWAGA! GORĄCA KOŃCÓWKA!";
+const char* WarningAdvancedString = "UWAGA! GORĄCA KOŃCÓWKA!"; // <=16 chars
+const char* SleepingTipAdvancedString = "Tip:";      // <=6 chars
+const char* IdleTipString = "Tip:";     // IdleTipString+IdleSetString <= 10
+const char* IdleSetString = " Set:";    // preferably start with a space; IdleTipString+IdleSetString <= 10
+const char* TipDisconnectedString = "TIP DISCONNECTED"; // <=16 chars
 
 const char SettingRightChar = 'P';
 const char SettingLeftChar = 'L';

--- a/workspace/TS100/src/main.cpp
+++ b/workspace/TS100/src/main.cpp
@@ -197,9 +197,9 @@ static bool checkVoltageForExit() {
     lcd.setCursor(0, 0);
     if (systemSettings.detailedSoldering) {
       lcd.setFont(1);
-      lcd.print("Undervoltage");
+      lcd.print(UndervoltageString);
       lcd.setCursor(0, 8);
-      lcd.print("Input V: ");
+      lcd.print(InputVoltageString);
       lcd.printNumber(getInputVoltageX10(systemSettings.voltageDiv) / 10, 2);
       lcd.drawChar('.');
       lcd.printNumber(getInputVoltageX10(systemSettings.voltageDiv) % 10, 1);
@@ -207,7 +207,7 @@ static bool checkVoltageForExit() {
 
     } else {
       lcd.setFont(0);
-      lcd.print("DC LOW");
+      lcd.print(UVLOWarningString);
     }
 
     lcd.refresh();
@@ -387,7 +387,7 @@ static int gui_showTipTempWarning() {
       lcd.setFont(1);
       lcd.print(WarningAdvancedString);
       lcd.setCursor(0, 8);
-      lcd.print("Tip Temp: ");
+      lcd.print(WarningTipTempString);
 
       if (systemSettings.temperatureInF) {
         lcd.printNumber(tipMeasurementToF(getTipRawTemp(0)), 3);
@@ -462,7 +462,7 @@ static int gui_SolderingSleepingMode() {
       lcd.setFont(1);
       lcd.print(SleepingAdvancedString);
       lcd.setCursor(0, 8);
-      lcd.print("Tip:");
+      lcd.print(SleepingTipAdvancedString);
       lcd.printNumber(tipTemp, 3);
       if (systemSettings.temperatureInF)
         lcd.print("F");
@@ -552,7 +552,7 @@ static void gui_solderingMode() {
     lcd.clearScreen();
     lcd.setFont(0);
     if (tipTemp > 16300) {
-      lcd.print("BAD TIP");
+      lcd.print(BadTipString);
       lcd.refresh();
       currentlyActiveTemperatureTarget = 0;
       waitForButtonPress();
@@ -766,19 +766,18 @@ void startGUITask(void const *argument) {
     if (systemSettings.detailedIDLE) {
       lcd.setFont(1);
       if (tipTemp > 470) {
-        lcd.print("Tip Disconnected!");
+        lcd.print(TipDisconnectedString);
       } else {
-        lcd.print("Tip:");
+        lcd.print(IdleTipString);
         if (systemSettings.temperatureInF)
           lcd.printNumber(tipMeasurementToF(getTipRawTemp(0)), 3);
         else
           lcd.printNumber(tipMeasurementToC(getTipRawTemp(0)), 3);
-        lcd.print(" ");
-        lcd.print("Set:");
+        lcd.print(IdleSetString);
         lcd.printNumber(systemSettings.SolderingTemp, 3);
       }
       lcd.setCursor(0, 8);
-      lcd.print("Input V: ");
+      lcd.print(InputVoltageString);
       lcd.printNumber(getInputVoltageX10(systemSettings.voltageDiv) / 10, 2);
       lcd.drawChar('.');
       lcd.printNumber(getInputVoltageX10(systemSettings.voltageDiv) % 10, 1);


### PR DESCRIPTION
Externalized strings:
* "Undervoltage"
* "Input V: "
* "DC LOW" (Using previously unused ULOWarningString)
* "Tip Temp: " (At temperature warning)
* "Tip:" (At sleeping advanced)
* "Tip:" (At idle screen)
* " Set:" (At idle screen)
* "BAD TIP"
* "Tip Disconnected!" (changed to "TIP DISCONNECTED" due to <=16 limit)

Max string length corrected from 17 to 16. Translations in some languages should be reviewed/corrected accordingly.
 
Additionally, added double-line menus for Croatian Language, together with some minor translation corrections.

**NOTE:** Warnings strings might be better if displayed with all-caps, such as "UNDERVOLTAGE" etc. I didn't change that in English (it is up to you, if you find it appropriate), but I did that in Croatian.
