### PR TITLE
Adjust left limit for drawing

### DIFF
--- a/workspace/TS100/src/OLED.cpp
+++ b/workspace/TS100/src/OLED.cpp
@@ -288,23 +288,31 @@ void OLED::drawArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
 	// Splat this from x->x+wide in two strides
 	if (x <= -wide)
 		return;    //cutoffleft
-	if ((x) > 96)
+	if (x > 96)
 		return;    //cutoff right
-	uint8_t width = wide;
-	if ((x + wide) > 96)
-		width = 96 - x; // trimming to draw partials
+
+	uint8_t visibleStart = 0;
+	uint8_t visibleEnd = wide;
+
+	// trimming to draw partials
+	uint8_t sum = x + wide;
+	if(sum < 0) {
+	  visibleStart -= sum;  //subtract negative value == add absolute value
+	}
+	if(sum > 96) {
+	  visibleEnd = 96 - x;
+	}
 
 	if (y == 0) {
 		//Splat first line of data
-		for (uint8_t xx = 0; xx < (width); xx++) {
+		for (uint8_t xx = visibleStart; xx < visibleEnd; xx++) {
 			firstStripPtr[xx + x] = ptr[xx];
 		}
 	}
 	if (y == 8 || height == 16) {
 		// Splat the second line
-		for (uint8_t xx = 0; xx < width; xx++) {
+		for (uint8_t xx = visibleStart; xx < visibleEnd; xx++) {
 			secondStripPtr[x + xx] = ptr[xx + (height == 16 ? wide : 0)];
-
 		}
 	}
 }

--- a/workspace/TS100/src/OLED.cpp
+++ b/workspace/TS100/src/OLED.cpp
@@ -295,11 +295,10 @@ void OLED::drawArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
 	uint8_t visibleEnd = wide;
 
 	// trimming to draw partials
-	uint8_t sum = x + wide;
-	if(sum < 0) {
-	  visibleStart -= sum;  //subtract negative value == add absolute value
+	if(x < 0) {
+	  visibleStart -= x;  //subtract negative value == add absolute value
 	}
-	if(sum > 96) {
+	if(x + wide > 96) {
 	  visibleEnd = 96 - x;
 	}
 

--- a/workspace/TS100/src/OLED.cpp
+++ b/workspace/TS100/src/OLED.cpp
@@ -286,7 +286,7 @@ void OLED::drawSymbol(uint8_t symbolID) {
 void OLED::drawArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
 		const uint8_t* ptr) {
 	// Splat this from x->x+wide in two strides
-	if (x < 0)
+	if (x <= -wide)
 		return;    //cutoffleft
 	if ((x) > 96)
 		return;    //cutoff right


### PR DESCRIPTION
Do draw area also if just part of it is visible - e.g. do not skip whole letter in rolling description if half of it can be shown.