### PR TITLE
Use LTO to save up to 7k of flash

### DIFF
--- a/workspace/TS100/Makefile
+++ b/workspace/TS100/Makefile
@@ -32,7 +32,7 @@ HEXFILE_DIR=Hexfile
 OUTPUT_DIR=Objects
 
 # code optimisation ------------------------------------------------------------
-OPTIM=-Os -finline-small-functions -findirect-inlining -fdiagnostics-color -ffunction-sections -fdata-sections
+OPTIM=-Os -flto -finline-small-functions -findirect-inlining -fdiagnostics-color -ffunction-sections -fdata-sections
 
 
 # global defines ---------------------------------------------------------------
@@ -73,7 +73,7 @@ LINKER_FLAGS=-Wl,--gc-sections 		\
 			-mcpu=cortex-m3		\
 			-mthumb			\
 			-mfloat-abi=soft	\
-			-lm
+			-lm -Os -flto -Wl,--undefined=vTaskSwitchContext
 
 # compiler flags ---------------------------------------------------------------
 CPUFLAGS=-D GCC_ARMCM3		\
@@ -185,13 +185,13 @@ all: $(OUT_HEXFILE).hex
 
 # Create hexfile
 %.hex : %.elf
-	$(SIZE) -x $^
+	$(SIZE) $^
 	$(OBJCOPY) $^ -O ihex $@
 
 $(OUT_HEXFILE).elf : $(OUT_OBJS) $(OUT_OBJS_CPP) $(OUT_OBJS_S) Makefile $(LDSCRIPT)
 	@test -d $(@D) || mkdir -p $(@D)
 	@echo Linking $(OUTPUT_EXE).elf
-	@$(CPP) $(CXXFLAGS) $(OUT_OBJS) $(OUT_OBJS_CPP) $(OUT_OBJS_S)  $(LIBS) $(LINKER_FLAGS)
+	@$(CPP) $(CXXFLAGS) $(OUT_OBJS_S) $(OUT_OBJS) $(OUT_OBJS_CPP) $(LIBS) $(LINKER_FLAGS)
 
 $(OUT_OBJS): $(OUTPUT_DIR)/%.o : %.c Makefile
 	@test -d $(@D) || mkdir -p $(@D)


### PR DESCRIPTION
LTO can make a significant impact on flash space when using ST HAL drivers.

I've tested it on my iron, seems to work fine. Had a slight problem with interrupt vectors optimizing out, but solved it by reordering link order on line 194 
Before:

```
arm-none-eabi-size Hexfile/TS100_EN.elf
   text	   data	    bss	    dec	    hex	filename
  43992	   1760	  13400	  59152	   e710	Hexfile/TS100_EN.elf

```

after:

```
arm-none-eabi-size Hexfile/TS100_EN.elf
   text	   data	    bss	    dec	    hex	filename
  38896	   1460	  13408	  53764	   d204	Hexfile/TS100_EN.elf
```


With some more optimizations, it might be possible to fit a small usb stack with CDC. :)

Tools used:
`gcc version 7.2.1 20170904 (release) [ARM/embedded-7-branch revision 255204] (GNU Tools for Arm Embedded Processors 7-2017-q4-majo`