### PR TITLE
Add binary generation to the Makefile

### DIFF
--- a/workspace/TS100/Makefile
+++ b/workspace/TS100/Makefile
@@ -177,7 +177,7 @@ OUT_OBJS_CPP=$(addprefix $(OUTPUT_DIR)/,$(OBJS_CPP))
 OUT_OBJS_S=$(addprefix $(OUTPUT_DIR)/,$(OBJS_S))
 OUT_HEXFILE=$(addprefix $(HEXFILE_DIR)/,$(OUTPUT_EXE))
 
-all: $(OUT_HEXFILE).hex
+all: $(OUT_HEXFILE).hex $(OUT_HEXFILE).bin
 
 #
 # The rule to create the target directory
@@ -187,6 +187,10 @@ all: $(OUT_HEXFILE).hex
 %.hex : %.elf
 	$(SIZE) $^
 	$(OBJCOPY) $^ -O ihex $@
+
+%.bin : %.elf
+	$(SIZE) $^
+	$(OBJCOPY) $^ -O binary $@
 
 $(OUT_HEXFILE).elf : $(OUT_OBJS) $(OUT_OBJS_CPP) $(OUT_OBJS_S) Makefile $(LDSCRIPT)
 	@test -d $(@D) || mkdir -p $(@D)


### PR DESCRIPTION
Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [X] The commit message make sense
- [X] The changes have been tested locally
<!--- - [ ] New features have been documented in the Wiki --->
<!--- - [ ] I'm willing to maintain this in the future (Totally Optional) --->


* **What kind of change does this PR introduce?** 
(Bug fix, feature, docs update, ...)

There's no way to generate the firmware in binary format using the Makefile. As a dapboot user (dapboot **only** takes binary, **not** intel hex ftw) I found out that this is really inconvenient so I decided to add binary file generation to the Makefile.

* **What is the current behavior?** 
(You can also link to an open issue here)

`make all` only generates the firmware in Intel HEX format (works for official DFU)

* **What is the new behavior (if this is a feature change)?**

`make all` generates the firmware in Intel HEX format (works for official DFU) and in binary format (works for dapboot)

* **Does this PR introduce a breaking change?** 
(What changes might users need to make in their application due to this PR?)

No

* **Other information**:

None