### PR TITLE
Display seconds until sleep in soldering mode.

### DIFF
--- a/workspace/TS100/src/main.cpp
+++ b/workspace/TS100/src/main.cpp
@@ -434,6 +434,24 @@ static int gui_SolderingSleepingMode() {
 	}
 	return 0;
 }
+
+static void display_countdown(int sleepThres) {
+	/*
+	 * Print seconds or minutes (if > 99 seconds) until sleep
+	 * mode is triggered.
+	 */
+	int lastEventTime = lastButtonTime < lastMovementTime ?
+	    lastMovementTime : lastButtonTime;
+	int downCount = sleepThres - xTaskGetTickCount() + lastEventTime;
+	if (downCount > 9900) {
+		lcd.printNumber(downCount/6000 + 1, 2);
+		lcd.print("M");
+	} else {
+		lcd.printNumber(downCount/100 + 1, 2);
+		lcd.print("S");
+	}
+}
+
 static void gui_solderingMode() {
 	/*
 	 * * Soldering (gui_solderingMode)
@@ -503,6 +521,12 @@ static void gui_solderingMode() {
 				lcd.print(SolderingAdvancedPowerPrompt);  //Power:
 				lcd.printNumber(getTipPWM(), 3);
 				lcd.print("%");
+
+				if (systemSettings.sensitivity && systemSettings.SleepTime)
+				{
+					lcd.print(" ");
+					display_countdown(sleepThres);
+				}
 
 				lcd.setCursor(0, 8);
 				lcd.print(SleepingTipAdvancedString);


### PR DESCRIPTION
Display seconds until sleep in soldering mode.
For time > 99 seconds display minutes instead.

Note: it is a fairly trivial change and I can imagine the feature is not desired by everyone. I used it while playing with different motion sensivity settings and made a pull request just in case.

* **Please check if the PR fulfills these requirements**
- [X] The commit message make sense
- [X] The changes have been tested locally
- [ ] New features have been documented in the Wiki
- [X] I'm willing to maintain this in the future (Totally Optional)

* **What kind of change does this PR introduce?** 
Feature

* **What is the current behavior?** 
The user has no feedback as to when the unit will enter sleep mode

* **What is the new behavior (if this is a feature change)?**
In the advanced settings next to the output power it will display the time left intil sleep.

* **Does this PR introduce a breaking change?** 
No

* **Other information**:
I assumed S and M are internationally acceptable for seconds and minutes as the translation file does not offer a constant for them.