### PR TITLE
Fixed incorrect Voltage Reading of the TS80 because of Calibration Value Capping

### DIFF
--- a/workspace/TS100/src/gui.cpp
+++ b/workspace/TS100/src/gui.cpp
@@ -874,11 +874,19 @@ static void settings_setCalibrateVIN(void) {
     osDelay(40);
 
     // Cap to sensible values
+#ifdef MODEL_TS80
+    if (systemSettings.voltageDiv < 500) {
+      systemSettings.voltageDiv = 500;
+    } else if (systemSettings.voltageDiv > 900) {
+      systemSettings.voltageDiv = 900;
+    }
+#else
     if (systemSettings.voltageDiv < 360) {
       systemSettings.voltageDiv = 360;
     } else if (systemSettings.voltageDiv > 520) {
       systemSettings.voltageDiv = 520;
     }
+#endif
   }
 }
 


### PR DESCRIPTION



Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [x ] The commit message make sense
- [ x] The changes have been tested locally
- [ x] New features have been documented in the Wiki
- [ x] I'm willing to maintain this in the future (Totally Optional)


* **What kind of change does this PR introduce?** 
(Bug fix, feature, docs update, ...)

#Bug fix

Fixed incorrect Calibration Value Capping when using the TS80.

* **What is the current behavior?** 
(You can also link to an open issue here)

Vin is not read properly because the Calibration Value of the TS80 has to be outside of the capping range of the TS100

* **What is the new behavior (if this is a feature change)?**

Added a new Cap for the TS80 with an Preprocessor define
