### PR TITLE
New build.sh script : detect languages with translation_*.json files

### DIFF
--- a/workspace/TS100/build.sh
+++ b/workspace/TS100/build.sh
@@ -1,103 +1,156 @@
-python ../../Translation\ Editor/make_translation.py ../../Translation\ Editor
+#!/bin/bash
 
-make clean
+TRANSLATION_DIR="../../Translation Editor"
+TRANSLATION_SCRIPT="make_translation.py"
+TRANSLATION_FILE_PATTERN="translation_*.json"
 
-# TS100
-make -j16 lang=EN
-rm -rf Objects/src
-make -j16 lang=BG
-rm -rf Objects/src
-make -j16 lang=CS
-rm -rf Objects/src
-make -j16 lang=DA
-rm -rf Objects/src
-make -j16 lang=DE
-rm -rf Objects/src
-make -j16 lang=ES
-rm -rf Objects/src
-make -j16 lang=FI
-rm -rf Objects/src
-make -j16 lang=FR
-rm -rf Objects/src
-make -j16 lang=HR
-rm -rf Objects/src
-make -j16 lang=HU
-rm -rf Objects/src
-make -j16 lang=IT
-rm -rf Objects/src
-make -j16 lang=LT
-rm -rf Objects/src
-make -j16 lang=NL
-rm -rf Objects/src
-make -j16 lang=NL_BE
-rm -rf Objects/src
-make -j16 lang=NO
-rm -rf Objects/src
-make -j16 lang=PL
-rm -rf Objects/src
-make -j16 lang=PT
-rm -rf Objects/src
-make -j16 lang=RU
-rm -rf Objects/src
-make -j16 lang=SK
-rm -rf Objects/src
-make -j16 lang=SR_CYRL
-rm -rf Objects/src
-make -j16 lang=SR_LATN
-rm -rf Objects/src
-make -j16 lang=SV
-rm -rf Objects/src
-make -j16 lang=TR
-rm -rf Objects/src
-make -j16 lang=UK
-rm -rf Objects/src
+# AVAILABLE_LANGUAGES will be calculating according to json files in $TRANSLATION_DIR
+AVAILABLE_LANGUAGES=()
+BUILD_LANGUAGES=()
+AVAILABLE_MODELS=("TS100" "TS80")
+BUILD_MODELS=()
 
-# TS80
-make -j16 lang=EN model=TS80
-rm -rf Objects/src
-make -j16 lang=BG model=TS80
-rm -rf Objects/src
-make -j16 lang=CS model=TS80
-rm -rf Objects/src
-make -j16 lang=DA model=TS80
-rm -rf Objects/src
-make -j16 lang=DE model=TS80
-rm -rf Objects/src
-make -j16 lang=ES model=TS80
-rm -rf Objects/src
-make -j16 lang=FI model=TS80
-rm -rf Objects/src
-make -j16 lang=FR model=TS80
-rm -rf Objects/src
-make -j16 lang=HR model=TS80
-rm -rf Objects/src
-make -j16 lang=HU model=TS80
-rm -rf Objects/src
-make -j16 lang=IT model=TS80
-rm -rf Objects/src
-make -j16 lang=LT model=TS80
-rm -rf Objects/src
-make -j16 lang=NL model=TS80
-rm -rf Objects/src
-make -j16 lang=NL_BE model=TS80
-rm -rf Objects/src
-make -j16 lang=NO model=TS80
-rm -rf Objects/src
-make -j16 lang=PL model=TS80
-rm -rf Objects/src
-make -j16 lang=PT model=TS80
-rm -rf Objects/src
-make -j16 lang=RU model=TS80
-rm -rf Objects/src
-make -j16 lang=SK model=TS80
-rm -rf Objects/src
-make -j16 lang=SR_CYRL model=TS80
-rm -rf Objects/src
-make -j16 lang=SR_LATN model=TS80
-rm -rf Objects/src
-make -j16 lang=SV model=TS80
-rm -rf Objects/src
-make -j16 lang=TR model=TS80
-rm -rf Objects/src
-make -j16 lang=UK model=TS80
-rm -rf Objects/src
+usage ()
+{
+  echo "Usage : $(basename $0) [-l <LANG_CODE>] [-m <TS100|TS80>] [-h]
+
+Parameters :
+    -l LANG_CODE : Force a specific language (E.g. : EN, FR, NL_BE, ...)
+    -m MODEL     : Force a specific model (E.g. : TS100 or TS80)
+    -h           : Show this help message
+
+INFO : By default, without parameters, the build is for all platforms and all languages" 1>&2
+  exit 1
+}
+
+checkLastCommand ()
+{
+    if [ $? -eq 0 ]
+    then
+        echo "    [Success]"
+        echo "*********************************************"
+    else
+        forceExit
+fi
+}
+
+forceExit ()
+{
+    echo "    [Error]"
+    echo "*********************************************"
+    echo " -- Stop on error --"
+    exit 1
+}
+
+isInArray ()
+{
+    local value="$1"   # Save first argument in a variable
+    shift              # Shift all arguments to the left (original $1 gets lost)
+    local array=("$@") # Rebuild the array with rest of arguments
+
+    for item in "${array[@]}"
+    do
+        [[ $value == "$item" ]] && return 0
+    done
+    return 1
+}
+
+while getopts h:l:m: option
+do
+    case "${option}" in
+        h)
+            usage
+            ;;
+        l)
+            LANGUAGE=${OPTARG}
+            ;;
+        m)
+            MODEL=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+echo "*********************************************"
+echo "             Builder for the"
+echo "      Alternate Open Source Firmware"
+echo "        for Miniware TS100 or TS80"
+echo "                                     by Ralim"
+echo "*********************************************"
+
+# Calculate available languages
+for file in $(find "$TRANSLATION_DIR" -name "$TRANSLATION_FILE_PATTERN" -exec basename {} ';')
+do
+    endIdx=$((${#file}-5))
+    AVAILABLE_LANGUAGES+=($(echo "$file" | cut -c13-$endIdx | tr [a-z] [A-Z]))
+done
+
+# Checking requested language
+echo "Available languages :"
+echo "    ${AVAILABLE_LANGUAGES[@]}"
+echo "Requested languages :"
+if [ -n "$LANGUAGE" ]
+then
+    if isInArray "$LANGUAGE" "${AVAILABLE_LANGUAGES[@]}"
+    then
+        echo "    $LANGUAGE" 
+        BUILD_LANGUAGES+=($LANGUAGE)
+    else
+        echo "    $LANGUAGE doesn't exist" 
+        forceExit
+    fi
+else
+	echo "    [ALL LANGUAGES]"
+    BUILD_LANGUAGES+=(${AVAILABLE_LANGUAGES[@]})
+fi
+echo "*********************************************"
+
+# Checking requested model
+echo "Available models :"
+echo "    ${AVAILABLE_MODELS[@]}"
+echo "Requested models :"
+if [ -n "$MODEL" ]
+then
+    if isInArray "$MODEL" "${AVAILABLE_MODELS[@]}"
+    then
+    	echo "    $MODEL" 
+        BUILD_MODELS+=($MODEL)
+    else
+        echo "    $MODEL doesn't exist" 
+        forceExit
+    fi
+else
+	echo "    [ALL MODELS]"
+    BUILD_MODELS+=(${AVAILABLE_MODELS[@]})
+fi
+echo "*********************************************"
+
+if [ ${#BUILD_LANGUAGES[@]} -gt 0 ] && [ ${#BUILD_MODELS[@]} -gt 0 ]
+then 
+    echo "Generating Translation.cpp"
+    python "$TRANSLATION_DIR/$TRANSLATION_SCRIPT" "$TRANSLATION_DIR" 1>/dev/null
+    checkLastCommand
+
+    echo "Cleaning previous builds"
+    make clean 1>/dev/null
+    checkLastCommand
+
+    for lang in "${BUILD_LANGUAGES[@]}"
+    do
+        for model in "${BUILD_MODELS[@]}"
+        do
+            echo "Building firmware for $model in $lang"
+            make -j16 lang=$lang model=$model 1>/dev/null
+            checkLastCommand
+            rm -rf Objects/src 1>/dev/null
+        done
+    done
+else
+    echo "Nothing to build. (no model or language specified)"
+    forceExit
+fi
+echo " -- Firmwares successfully generated --"
+echo "End..."

--- a/workspace/TS100/build.sh
+++ b/workspace/TS100/build.sh
@@ -12,7 +12,7 @@ BUILD_MODELS=()
 
 usage ()
 {
-  echo "Usage : $(basename $0) [-l <LANG_CODE>] [-m <TS100|TS80>] [-h]
+  echo "Usage : $(basename "$0") [-l <LANG_CODE>] [-m <TS100|TS80>] [-h]
 
 Parameters :
     -l LANG_CODE : Force a specific language (E.g. : EN, FR, NL_BE, ...)
@@ -85,46 +85,46 @@ echo "*********************************************"
 for file in $(find "$TRANSLATION_DIR" -name "$TRANSLATION_FILE_PATTERN" -exec basename {} ';')
 do
     endIdx=$((${#file}-5))
-    AVAILABLE_LANGUAGES+=($(echo "$file" | cut -c13-$endIdx | tr [a-z] [A-Z]))
+    AVAILABLE_LANGUAGES+=($(echo "$file" | cut -c13-$endIdx | tr "[a-z]" "[A-Z]"))
 done
 
 # Checking requested language
 echo "Available languages :"
-echo "    ${AVAILABLE_LANGUAGES[@]}"
+echo "    ${AVAILABLE_LANGUAGES[*]}"
 echo "Requested languages :"
 if [ -n "$LANGUAGE" ]
 then
     if isInArray "$LANGUAGE" "${AVAILABLE_LANGUAGES[@]}"
     then
         echo "    $LANGUAGE" 
-        BUILD_LANGUAGES+=($LANGUAGE)
+        BUILD_LANGUAGES+=("$LANGUAGE")
     else
         echo "    $LANGUAGE doesn't exist" 
         forceExit
     fi
 else
 	echo "    [ALL LANGUAGES]"
-    BUILD_LANGUAGES+=(${AVAILABLE_LANGUAGES[@]})
+    BUILD_LANGUAGES+=("${AVAILABLE_LANGUAGES[@]}")
 fi
 echo "*********************************************"
 
 # Checking requested model
 echo "Available models :"
-echo "    ${AVAILABLE_MODELS[@]}"
+echo "    ${AVAILABLE_MODELS[*]}"
 echo "Requested models :"
 if [ -n "$MODEL" ]
 then
     if isInArray "$MODEL" "${AVAILABLE_MODELS[@]}"
     then
     	echo "    $MODEL" 
-        BUILD_MODELS+=($MODEL)
+        BUILD_MODELS+=("$MODEL")
     else
         echo "    $MODEL doesn't exist" 
         forceExit
     fi
 else
 	echo "    [ALL MODELS]"
-    BUILD_MODELS+=(${AVAILABLE_MODELS[@]})
+    BUILD_MODELS+=("${AVAILABLE_MODELS[@]}")
 fi
 echo "*********************************************"
 
@@ -143,7 +143,7 @@ then
         for lang in "${BUILD_LANGUAGES[@]}"
         do
             echo "Building firmware for $model in $lang"
-            make -j16 lang=$lang model=$model 1>/dev/null
+            make -j16 lang="$lang" model="$model" 1>/dev/null
             checkLastCommand
             rm -rf Objects/src 1>/dev/null
         done

--- a/workspace/TS100/build.sh
+++ b/workspace/TS100/build.sh
@@ -138,9 +138,9 @@ then
     make clean 1>/dev/null
     checkLastCommand
 
-    for lang in "${BUILD_LANGUAGES[@]}"
+    for model in "${BUILD_MODELS[@]}"
     do
-        for model in "${BUILD_MODELS[@]}"
+        for lang in "${BUILD_LANGUAGES[@]}"
         do
             echo "Building firmware for $model in $lang"
             make -j16 lang=$lang model=$model 1>/dev/null

--- a/workspace/TS100/build.sh
+++ b/workspace/TS100/build.sh
@@ -2,7 +2,6 @@
 
 TRANSLATION_DIR="../../Translation Editor"
 TRANSLATION_SCRIPT="make_translation.py"
-TRANSLATION_FILE_PATTERN="translation_*.json"
 
 # AVAILABLE_LANGUAGES will be calculating according to json files in $TRANSLATION_DIR
 AVAILABLE_LANGUAGES=()
@@ -82,11 +81,12 @@ echo "                                     by Ralim"
 echo "*********************************************"
 
 # Calculate available languages
-for file in $(find "$TRANSLATION_DIR" -name "$TRANSLATION_FILE_PATTERN" -exec basename {} ';')
+for f in "$TRANSLATION_DIR"/translation_*.json
 do
-    endIdx=$((${#file}-5))
-    AVAILABLE_LANGUAGES+=($(echo "$file" | cut -c13-$endIdx | tr "[a-z]" "[A-Z]"))
-done
+    lang_json=${f#*/translation_}      # Remove ".../translation_"
+    lang=${lang_json%.json}            # Remove ".json"
+    AVAILABLE_LANGUAGES+=("${lang^^}") # Convert to uppercase
+done    
 
 # Checking requested language
 echo "Available languages :"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message make sense
- [x] The changes have been tested locally
- [ ] New features have been documented in the Wiki
- [x] I'm willing to maintain this in the future (Totally Optional)


* **What kind of change does this PR introduce?** 
New script to generate all *.hex files
```
Usage : ./build.sh [-l <LANG_CODE>] [-m <TS100|TS80>] [-h]

Parameters :
    -l LANG_CODE : Force a specific language (E.g. : EN, FR, NL_BE, ...)
    -m MODEL     : Force a specific model (E.g. : TS100 or TS80)
    -h           : Show this help message

INFO : By default, without parameters, the build is for all platforms and all languages
```

The new script has been tested on git bash on Windows and on Linux

* **What is the current behavior?** 
Each time a new "translation_*.json" file is added by a contributor, the build script has to be updated
The build script impose to build all languages for all models

* **What is the new behavior (if this is a feature change)?**
New script parse "Translation Editor" directory to find all "translation_*.json" files and iterate on those files to detect all available languages 
New script allow to make a build for a specific language and/or a specific model
New script checks if requested language and/or model is available

* **Does this PR introduce a breaking change?** 
n.a


* **Other information**:
