### PR TITLE
adjust watts for PWM duty cycle

### DIFF
--- a/workspace/TS100/src/main.cpp
+++ b/workspace/TS100/src/main.cpp
@@ -977,10 +977,10 @@ void startPIDTask(void const *argument __unused) {
 				// Once we have feed-forward temp estimation we should be able to better tune this.
 
 #ifdef MODEL_TS100
-				const uint16_t mass = 1690 / 20; // divide here so division is compile-time.
+				const uint16_t mass = 2020 / 20; // divide here so division is compile-time.
 #endif
 #ifdef MODEL_TS80
-				const uint16_t mass = 1690 / 50;
+				const uint16_t mass = 2020 / 50;
 #endif
 
 				int32_t milliWattsNeeded = tempToMilliWatts(tempError.average(),

--- a/workspace/TS100/src/power.cpp
+++ b/workspace/TS100/src/power.cpp
@@ -10,7 +10,8 @@
 #include <hardware.h>
 
 uint8_t tipResistance = 85; //x10 ohms, 8.5 typical for ts100, 4.5 typical for ts80
-const uint8_t maxPWM = 255;
+const uint16_t powerPWM = 255;
+const uint16_t totalPWM = 255+50; // Setup.c:sConfigOC.Pulse, the full PWM cycle
 
 history<uint16_t, oscillationPeriod> milliWattHistory = { { 0 }, 0, 0 };
 
@@ -42,10 +43,10 @@ uint8_t milliWattsToPWM(int32_t milliWatts, uint8_t divisor) {
 	// Scale input milliWatts to the pwm rate
 	int32_t v = getInputVoltageX10(divisor);// 100 = 10v
 	int32_t availableMilliWatts = v * v / tipResistance;
-	int32_t pwm = maxPWM * milliWatts / availableMilliWatts;
+	int32_t pwm = (powerPWM * totalPWM / powerPWM) * milliWatts / availableMilliWatts;
 
-	if (pwm > maxPWM) {
-		pwm = maxPWM;
+	if (pwm > powerPWM) {
+		pwm = powerPWM;
 	} else if (pwm < 0) {
 		pwm = 0;
 	}
@@ -54,5 +55,5 @@ uint8_t milliWattsToPWM(int32_t milliWatts, uint8_t divisor) {
 
 int32_t PWMToMilliWatts(uint8_t pwm, uint8_t divisor) {
 	int32_t v = getInputVoltageX10(divisor);
-	return pwm * (v * v / tipResistance) / maxPWM;
+	return pwm * (v * v / tipResistance) / (powerPWM * totalPWM / powerPWM);
 }


### PR DESCRIPTION
This reduces the watt calculations by ~20%.

Because our mass calculation was done before-hand, we need to counter this by boosting the mass by ~20%. `(1690 * ((255+50) / 255))`

This code hasn't been tested.