### PR TITLE
Enable flt-lto-objects for listing generation

### DIFF
--- a/workspace/TS100/Makefile
+++ b/workspace/TS100/Makefile
@@ -35,7 +35,7 @@ HEXFILE_DIR=Hexfile
 OUTPUT_DIR=Objects
 
 # code optimisation ------------------------------------------------------------
-OPTIM=-Os -flto -finline-small-functions -findirect-inlining -fdiagnostics-color -ffunction-sections -fdata-sections
+OPTIM=-Os -flto -ffat-lto-objects -finline-small-functions -findirect-inlining -fdiagnostics-color -ffunction-sections -fdata-sections
 
 
 # global defines ---------------------------------------------------------------


### PR DESCRIPTION
I suspect that since -flto was added listing generation wasn't working.
-ffat-lto-objects allows tools like objdump to still work by including
both the internal compiler representation (for LTO) and generated code
in the .o files. It increases the compile time from 12s to 17s on my
machine but I think it is small enough cost for the benefit.