### PR TITLE
Fix build on macOS

### DIFF
--- a/workspace/TS100/build.sh
+++ b/workspace/TS100/build.sh
@@ -83,9 +83,7 @@ echo "*********************************************"
 # Calculate available languages
 for f in "$TRANSLATION_DIR"/translation_*.json
 do
-    lang_json=${f#*/translation_}      # Remove ".../translation_"
-    lang=${lang_json%.json}            # Remove ".json"
-    AVAILABLE_LANGUAGES+=("${lang^^}") # Convert to uppercase
+    AVAILABLE_LANGUAGES+=(`echo $f | tr "[:lower:]" "[:upper:]" | sed "s/[^_]*_//" | sed "s/\.JSON//g"`)
 done    
 
 # Checking requested language


### PR DESCRIPTION
Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [x] The commit message make sense
- [x] The changes have been tested locally
- [ ] New features have been documented in the Wiki
- [ ] I'm willing to maintain this in the future (Totally Optional)


* **What kind of change does this PR introduce?** 

The highest version of bash shipped by vanilla macOS is 3.2, and it will stay like that for the foreseeable future (bash being removed as default in 10.15 is a strong indicator for that).

The build.sh script used Bash 4.x syntax for enumerating available translations - this patch dials back the clock to Bash 3.x making things work again on macOS and (hopefully) still maintaining functionality on other platforms that use a newer version of Bash.


* **What is the current behavior?** 
```bash
❯ ./build.sh
*********************************************
             Builder for the
      Alternate Open Source Firmware
        for Miniware TS100 or TS80
                                     by Ralim
*********************************************
./build.sh: line 88: ${lang^^}: bad substitution
Available languages :

Requested languages :
    [ALL LANGUAGES]
*********************************************
Available models :
    TS100 TS80
Requested models :
    [ALL MODELS]
*********************************************
Nothing to build. (no model or language specified)
    [Error]
*********************************************
 -- Stop on error --
```

`${variable^^}` was introduced in Bash 4.x, whilst the latest released version of Bash on macOS is still 3.x

* **What is the new behavior (if this is a feature change)?**

The build script now correctly enumerates available languages and proceeds with the build process.

* **Does this PR introduce a breaking change?** 

Hopefully not, the changes made to the script should follow POSIX syntax.


* **Other information**: