### PR TITLE
changed Python logo converter to use correct line endings on all OSes

### DIFF
--- a/Bootup Logo/python_logo_converter/img2ts100.py
+++ b/Bootup Logo/python_logo_converter/img2ts100.py
@@ -229,7 +229,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     try:
-        with open(args.output_filename, 'w') as output:
+        with open(args.output_filename, 'w', newline='\r\n') as output:
             img2hex(args.input_filename,
                     output,
                     args.preview,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message make sense
- [x] The changes have been tested locally
- [ ]  New features have been documented in the Wiki


* **What kind of change does this PR introduce?** 
This should fix issues people have been having with the Python logo converter script producing invalid HEX files when used with DFU version 3.45 (issues #460 and #437).


* **What is the current behavior?** 
The Python converter script works under Windows but not macOS. When run under Windows, the correct line ending of "\r\n" is output to the HEX file. But under macOS, the line ending is just "\n", which the iron rejects (when the USB MSD re-appears, the extension changes to .ERR).

   A previous pull request (#491) addressed this issue for Windows users. Before that pull request, the script was generating "\r\r\n" under Windows, which the iron also rejected. However, this PR also broke the script for Mac and Linux users.


* **What is the new behavior (if this is a feature change)?**
The script should generate the correct line ending of "\r\n" under all OSes.


* **Does this PR introduce a breaking change?** 
No touches to the firmware or anything. Just one line in the Python file changed. The ```newline``` argument used to fix this appears to not work in Python 2.7, so it should be documented in the wiki that the script needs to be run with Python 3.

* **Other Information**
Tested in macOS 10.14, Windows 8.1, and Ubuntu 18.04 and with DFU 3.45.