### PR TITLE
Speed up accelerometer driver data processing.

### DIFF
--- a/workspace/TS100/Core/Inc/LIS2DH12.hpp
+++ b/workspace/TS100/Core/Inc/LIS2DH12.hpp
@@ -34,7 +34,7 @@ public:
 		return static_cast<Orientation>((FRToSI2C::I2C_RegisterRead(LIS2DH_I2C_ADDRESS,LIS_INT2_SRC) >> 2) - 1);
 #endif
 	}
-	static void getAxisReadings(int16_t *x, int16_t *y, int16_t *z);
+	static void getAxisReadings(int16_t& x, int16_t& y, int16_t& z);
 
 private:
 };

--- a/workspace/TS100/Core/Inc/MMA8652FC.hpp
+++ b/workspace/TS100/Core/Inc/MMA8652FC.hpp
@@ -19,7 +19,7 @@ public:
 
 	static void initalize();		// Initalize the system
 	static Orientation getOrientation();// Reads the I2C register and returns the orientation (true == left)
-	static void getAxisReadings(int16_t *x, int16_t *y, int16_t *z);
+	static void getAxisReadings(int16_t& x, int16_t& y, int16_t& z);
 
 private:
 };

--- a/workspace/TS100/Core/Src/LIS2DH12.cpp
+++ b/workspace/TS100/Core/Src/LIS2DH12.cpp
@@ -5,9 +5,10 @@
  *      Author: Ralim
  */
 
-#include <LIS2DH12.hpp>
-#include "cmsis_os.h"
+#include <array>
 
+#include "LIS2DH12.hpp"
+#include "cmsis_os.h"
 
 typedef struct {
         const uint8_t reg;
@@ -36,14 +37,14 @@ void LIS2DH12::initalize() {
     }
 }
 
-void LIS2DH12::getAxisReadings(int16_t* x, int16_t* y, int16_t* z) {
-	uint8_t tempArr[6];
-FRToSI2C::Mem_Read(LIS2DH_I2C_ADDRESS, 0xA8, I2C_MEMADD_SIZE_8BIT,
-			(uint8_t*) tempArr, 6);
+void LIS2DH12::getAxisReadings(int16_t& x, int16_t& y, int16_t& z) {
+    std::array<int16_t, 3> sensorData;
 
-	(*x) = ((uint16_t) (tempArr[1] << 8 | tempArr[0]));
-	(*y) = ((uint16_t) (tempArr[3] << 8 | tempArr[2]));
-	(*z) = ((uint16_t) (tempArr[5] << 8 | tempArr[4]));
+    FRToSI2C::Mem_Read(LIS2DH_I2C_ADDRESS, 0xA8, I2C_MEMADD_SIZE_8BIT,
+        reinterpret_cast<uint8_t*>(sensorData.begin()),
+        sensorData.size() * sizeof(int16_t));
+
+    x = sensorData[0];
+    y = sensorData[1];
+    z = sensorData[2];
 }
-
-

--- a/workspace/TS100/Core/Src/MMA8652FC.cpp
+++ b/workspace/TS100/Core/Src/MMA8652FC.cpp
@@ -5,7 +5,9 @@
  *      Author: Ben V. Brown
  */
 
-#include <MMA8652FC.hpp>
+#include <array>
+
+#include "MMA8652FC.hpp"
 #include "cmsis_os.h"
 
 typedef struct {
@@ -62,12 +64,15 @@ Orientation MMA8652FC::getOrientation() {
 
 	return ORIENTATION_FLAT;
 }
-void MMA8652FC::getAxisReadings(int16_t *x, int16_t *y, int16_t *z) {
-	uint8_t tempArr[6];
-	FRToSI2C::Mem_Read( MMA8652FC_I2C_ADDRESS, OUT_X_MSB_REG, I2C_MEMADD_SIZE_8BIT,
-			(uint8_t*) tempArr, 6);
 
-	(*x) = tempArr[0] << 8 | tempArr[1];
-	(*y) = tempArr[2] << 8 | tempArr[3];
-	(*z) = tempArr[4] << 8 | tempArr[5];
+void MMA8652FC::getAxisReadings(int16_t& x, int16_t& y, int16_t& z) {
+	std::array<int16_t, 3> sensorData;
+
+	FRToSI2C::Mem_Read(MMA8652FC_I2C_ADDRESS, OUT_X_MSB_REG, I2C_MEMADD_SIZE_8BIT,
+		reinterpret_cast<uint8_t*>(sensorData.begin()),
+		sensorData.size() * sizeof(int16_t));
+
+	x = static_cast<int16_t>(__builtin_bswap16(*reinterpret_cast<uint16_t*>(&sensorData[0])));
+	y = static_cast<int16_t>(__builtin_bswap16(*reinterpret_cast<uint16_t*>(&sensorData[1])));
+	z = static_cast<int16_t>(__builtin_bswap16(*reinterpret_cast<uint16_t*>(&sensorData[2])));
 }

--- a/workspace/TS100/Core/Src/main.cpp
+++ b/workspace/TS100/Core/Src/main.cpp
@@ -254,10 +254,10 @@ void startMOVTask(void const *argument __unused) {
 		threshold -= systemSettings.sensitivity * 200;  // 200 is the step size
 
 		if (PCBVersion == 2) {
-			LIS2DH12::getAxisReadings(&tx, &ty, &tz);
+			LIS2DH12::getAxisReadings(tx, ty, tz);
 			rotation = LIS2DH12::getOrientation();
 		} else if (PCBVersion == 1) {
-			MMA8652FC::getAxisReadings(&tx, &ty, &tz);
+			MMA8652FC::getAxisReadings(tx, ty, tz);
 			rotation = MMA8652FC::getOrientation();
 		}
 		if (systemSettings.OrientationMode == 2) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message make sense
- [x] The changes have been tested locally (more about that later)
- [ ] Are there any breaking changes

* **What kind of change does this PR introduce?** 
XYZ acceleration data is processed in a better fashion to be used in the control loop.  If less time is spent waiting for accelerometer data to be ready maybe reading frequency can be bumped up a bit for more responsive operations.

* **What is the current behavior?** 
I2C accelerometer data is preprocessed to be in little-endian format before being used by the control loop. However:

* LIS2DH12 data is already in little-endian format as it comes out of the wire, yet the data is read byte by byte and manually converted into little-endian 16 bits integers in-memory.
* MMA8652FC data is in big-endian format, but the conversion step does not make use of the `REV16` opcode which performs byte-swaps at the CPU register level.

* **What is the new behavior (if this is a feature change)?**

LIS2DH12 data is interpreted as a stream of int16_t variables in a buffer, which allows direct assignment to variables without any intermediate conversion.

MMA8652FC is converted using GCC's `__builtin_bswap16` builtin function, that on Cortex-M processors maps to the `REV16` intrinsic.

LIS2DH12 - Before:

```asm
	(*x) = ((uint16_t) (tempArr[1] << 8 | tempArr[0]));
  18:	f89d 2009 	ldrb.w	r2, [sp, #9]
  1c:	f89d 3008 	ldrb.w	r3, [sp, #8]
  20:	ea43 2302 	orr.w	r3, r3, r2, lsl #8
  24:	8033      	strh	r3, [r6, #0]
	(*y) = ((uint16_t) (tempArr[3] << 8 | tempArr[2]));
  26:	f89d 200b 	ldrb.w	r2, [sp, #11]
  2a:	f89d 300a 	ldrb.w	r3, [sp, #10]
  2e:	ea43 2302 	orr.w	r3, r3, r2, lsl #8
  32:	802b      	strh	r3, [r5, #0]
	(*z) = ((uint16_t) (tempArr[5] << 8 | tempArr[4]));
  34:	f89d 200d 	ldrb.w	r2, [sp, #13]
  38:	f89d 300c 	ldrb.w	r3, [sp, #12]
  3c:	ea43 2302 	orr.w	r3, r3, r2, lsl #8
  40:	8023      	strh	r3, [r4, #0]
```

LIS2DH12 - After:

```asm
    x = sensorData[0];
  18:   f8bd 3008       ldrh.w  r3, [sp, #8]
  1c:   8033            strh    r3, [r6, #0]
    y = sensorData[1];
  1e:   f8bd 300a       ldrh.w  r3, [sp, #10]
  22:   802b            strh    r3, [r5, #0]
    z = sensorData[2];
  24:   f8bd 300c       ldrh.w  r3, [sp, #12]
  28:   8023            strh    r3, [r4, #0]
```

MMA8652FC - Before:

```asm
        (*x) = tempArr[0] << 8 | tempArr[1];
  18:   f89d 2008       ldrb.w  r2, [sp, #8]
  1c:   f89d 3009       ldrb.w  r3, [sp, #9]
  20:   ea43 2302       orr.w   r3, r3, r2, lsl #8
  24:   8033            strh    r3, [r6, #0]
        (*y) = tempArr[2] << 8 | tempArr[3];
  26:   f89d 200a       ldrb.w  r2, [sp, #10]
  2a:   f89d 300b       ldrb.w  r3, [sp, #11]
  2e:   ea43 2302       orr.w   r3, r3, r2, lsl #8
  32:   802b            strh    r3, [r5, #0]
        (*z) = tempArr[4] << 8 | tempArr[5];
  34:   f89d 200c       ldrb.w  r2, [sp, #12]
  38:   f89d 300d       ldrb.w  r3, [sp, #13]
  3c:   ea43 2302       orr.w   r3, r3, r2, lsl #8
  40:   8023            strh    r3, [r4, #0]
```

MMA8652FC - After:

```asm
    x = static_cast<int16_t>(__builtin_bswap16(*reinterpret_cast<uint16_t*>(&sensorData[0])));
  18:   f8bd 3008       ldrh.w  r3, [sp, #8]
  1c:   ba5b            rev16   r3, r3
  1e:   8033            strh    r3, [r6, #0]
    y = static_cast<int16_t>(__builtin_bswap16(*reinterpret_cast<uint16_t*>(&sensorData[1])));
  20:   f8bd 300a       ldrh.w  r3, [sp, #10]
  24:   ba5b            rev16   r3, r3
  26:   802b            strh    r3, [r5, #0]
    z = static_cast<int16_t>(__builtin_bswap16(*reinterpret_cast<uint16_t*>(&sensorData[2])));
  28:   f8bd 300c       ldrh.w  r3, [sp, #12]
  2c:   ba5b            rev16   r3, r3
  2e:   8023            strh    r3, [r4, #0]
```

* **Does this PR introduce a breaking change?** 

None known, _however_ I only own a TS100 with the LIS2DH12 accelerometer chip on board.  I tested equality of values read by the sensor via the old and the new code for the LIS2DH12 driver and it seems to work fine.  In theory the MMA8652FC should work as well, but it has not been tested.

* **Other information**:

Incidentally, the usage of `__builtin_bswap16` reduces the code size by a tiny amount as well - which can be used in the logo data manipulation too.  Unfortunately I cannot test that since on my iron I can't seem to be able to flash any logo data, whilst firmware code upload sort of works (need to try twice each time, but still...).