### PR TITLE
Grammar and other small fixes

### DIFF
--- a/History.md
+++ b/History.md
@@ -24,21 +24,21 @@ V1.16
 
 V1.15
 
-* Added support for a custom bootup logo to be programmed via the DFU bootloader.
+* Added support for a custom bootup logo to be programmed via the DFU bootloader
 
 V1.14
 
-* Changed input voltage cutoff to be based on cell count rather than voltage.
+* Changed input voltage cutoff to be based on cell count rather than voltage
 
 V1.13
 
 * Swapped buttons for menu to prevent accidentally changing first menu item
-* Added auto key repeat.
+* Added auto key repeat
 
 V1.12
 
 * Increases sensitivity options to be 1*9 with 0 off state
-* Fixes issue where going from COOL *> soldering can leave screen off.
+* Fixes issue where going from COOL *> soldering can leave screen off
 
 V1.11
 
@@ -77,7 +77,7 @@ V1.04
 * Allows temperature offset calibration
 * Nicer idle screen
 
-V1.03 
+V1.03
 
 * Improved Button handling
 * Ability to set motion sensitivity
@@ -85,5 +85,5 @@ V1.03
 
 V1.02
 
-* Adds hold both buttons on IDLE to access the therometer mode.
-* Changes the exit soldering mode to be holding both buttons (Like original firmware).
+* Adds hold both buttons on IDLE to access the therometer mode
+* Changes the exit soldering mode to be holding both buttons (Like original firmware)

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -21,9 +21,9 @@ Please edit this template and fill out all the information you can (where releva
 
 ***Steps to reproduce:***
 
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ***Video of problem if hard to reproduce***
 
@@ -40,7 +40,6 @@ On the idle screen, you can hold the settings button and it will show you the fi
   - Power Supply (Voltage and Current Rating) :
 
 
-* **Other information** 
+* **Other information**
 
 If submitting graphics to go on the iron, please use BMP or PNG files over JPG.
-

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,16 +2,16 @@
 Please try and fill out this template where possible, not all fields are required and can be removed.
 
 * **Please check if the PR fulfills these requirements**
-- [] The commit message make sense
+- [] The commit message makes sense
 - [] The changes have been tested locally
 - [] Are there any breaking changes
 
-* **What kind of change does this PR introduce?** 
+* **What kind of change does this PR introduce?**
 (Bug fix, feature, docs update, ...)
 
 
 
-* **What is the current behavior?** 
+* **What is the current behavior?**
 (You can also link to an open issue here)
 
 
@@ -20,7 +20,7 @@ Please try and fill out this template where possible, not all fields are require
 
 
 
-* **Does this PR introduce a breaking change?** 
+* **Does this PR introduce a breaking change?**
 (What changes might users need to make in their application due to this PR?)
 
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ This project is considered feature complete for use as a soldering iron, *so ple
 * Can disable movement detection if desired
 * Full tip profile calibration
 * Boost mode lets you temporarily change the temperature when soldering (ie raise the temperature for short periods of time)
-* (TS100) Battery charge level indicator if power source set to a lipo cell count.
-* (TS80) Power bank operating voltage is displayed.
-* Custom boot up logo support.
+* (TS100) Battery charge level indicator if power source set to a lipo cell count
+* (TS80) Power bank operating voltage is displayed
+* Custom boot up logo support
 * Automatic LCD rotation based on the orientation
 * Supports both the version 1 and version 2 hardware (different accelerometers)
 
 # Upgrading your iron
 
-This is completely safe, but if it goes wrong just put the .hex file from the official website onto the unit and your back to the old firmware. Downloads for the hex files to flash are available on the [releases page.](https://github.com/Ralim/ts100/releases) The file you want is called *(MODEL)_EN.hex* unless you want the translations, they are (MODEL)_*language short name*.hex. Where (MODEL) is either TS100 or TS80.
+This is completely safe, but if it goes wrong just put the .hex file from the official website onto the unit and you're back to the old firmware. Downloads for the hex files to flash are available on the [releases page.](https://github.com/Ralim/ts100/releases) The file you want is called *(MODEL)_EN.hex* unless you want the translations, they are (MODEL)_*language short name*.hex. Where (MODEL) is either TS100 or TS80.
 
 Officially the bootloader on the iron only works under Windows. However, users have reported that it does work under Mac, and can be made to work under Linux *sometimes*. Details over on the [wiki page](https://github.com/Ralim/ts100/wiki/Upgrading-Firmware).
 
@@ -45,7 +45,7 @@ Officially the bootloader on the iron only works under Windows. However, users h
 2. The unit will appear as a USB drive.
 3. Drag the .hex file onto the USB drive.
 4. The unit will disconnect and reconnect.
-5. The filename will have changed to end in .RDY or .ERR 
+5. The filename will have changed to end in .RDY or .ERR
 6. If it ends with .RDY you're done! Otherwise, something went wrong.
 7. If it didn't work the first time, try copying the file again without disconnecting the iron, often it will work on the second shot.
 8. Disconnect the USB and power up the iron. You're good to go.
@@ -55,13 +55,13 @@ Officially the bootloader on the iron only works under Windows. However, users h
 For the more adventurous out there, you can also load this firmware onto the device using an SWD programmer.
 On the bottom of the MCU riser PCB, there are 4 pads for programming.
 There is a complete device flash backup included in this repository. (Note this includes the bootloader, so will need an SWD programmer to load onto the unit).
-For the TS80 the SWD pins are used for the QC negotiation, so you can actually connect to the SWD power via the USB connector
+For the TS80 the SWD pins are used for the QC negotiation, so you can actually connect to the SWD power via the USB connector.
 
 ## Setting a custom bootup image
 
 This firmware uses a different method of updating the bootup image.
 This removes the need for emulating a USB drive on the iron just to allow for a bootup image to be setup.
-There are further instructions on the [wiki](https://github.com/Ralim/ts100/wiki/Logo-Editor). 
+There are further instructions on the [wiki](https://github.com/Ralim/ts100/wiki/Logo-Editor).
 Instructions are kept on the wiki so that users can update the information if they find extra helpful information.
 
 # Menu System
@@ -70,9 +70,9 @@ This new firmware uses a new menu system to allow access to the settings on the 
 When on the main screen, the unit shows prompts for the two most common operations.
 
 * Pressing the button near the tip enters soldering mode
-* Pressing the button near the USB enters the settings menu.
-* Holding the button near the tip will enter soldering temperature adjust mode (This is the same as the one in the soldering menu, just to let you edit before heating up).
-* Holding the button near the USB end will show the firmware version details.
+* Pressing the button near the USB enters the settings menu
+* Holding the button near the tip will enter soldering temperature adjust mode (This is the same as the one in the soldering menu, just to let you edit before heating up)
+* Holding the button near the USB end will show the firmware version details
 
 More details are over in the [Menu information.](menu.md)
 
@@ -80,9 +80,9 @@ More details are over in the [Menu information.](menu.md)
 
 
 If you love this firmware and want to continue my caffeine addiction, you can do so here (or email me for other options) : https://paypal.me/RalimTek
-I also want to should out to all of the [Fantastic Contributors](https://github.com/Ralim/ts100/graphs/contributors).
+I also want to give a shout out to all of the [Fantastic Contributors](https://github.com/Ralim/ts100/graphs/contributors).
 
-Especially to the following users, who have helped in various ways that are massively appreciated.:
+Especially to the following users, who have helped in various ways that are massively appreciated:
 
 * [dhiltonp](https://github.com/dhiltonp)
 * [Mrkvozrout](https://github.com/Mrkvozrout)
@@ -101,6 +101,5 @@ The FreeRToS is under its own licence.
 
 ## Commercial Use
 
-This software is provided as-is, so I cannot provide any commercial support for the firmware. However, you are more than welcome to distribute links to the firmware, or provide irons with this software on them. 
+This software is provided as-is, so I cannot provide any commercial support for the firmware. However, you are more than welcome to distribute links to the firmware, or provide irons with this software on them.
 Please do not re-host the files, but rather link to this page, so that there are no old versions of the firmware scattered around. If this firmware does make you money, it would be nice to receive a donation, however, there is no enforcement.
-

--- a/Translation.md
+++ b/Translation.md
@@ -3,4 +3,4 @@ If you would like to contribute a translation, use the [Translation Editor](http
 
 [Open a reference language file and optionally a target language file](https://github.com/Ralim/ts100/tree/master/Translation%20Editor).
 
-You can create a pull request with the new / updated json configuration file, and this will include this language into the new builds for the firmware
+You can create a pull request with the new / updated json configuration file, and this will include this language into the new builds for the firmware.

--- a/development.md
+++ b/development.md
@@ -4,18 +4,17 @@ Building this software can be performed two ways, using the STMCubeIDE or using 
 
 ## STM Cube IDE
 
-The repository is setup to try and make this painless, when starting the IDE you can import the project by pointing the internal search to the workspace folder of this repository. If you start with a fresh installation, close the welcome screen tab, and then in the left sidebar, there is an optiom to "import". Select General -> Import existing projects -> Set the top location option to this repositories workspace -> Should find the TS100 project.
+The repository is setup to try and make this painless, when starting the IDE you can import the project by pointing the internal search to the workspace folder of this repository. If you start with a fresh installation, close the welcome screen tab, and then in the left sidebar, there is an option to "import". Select General -> Import existing projects -> Set the top location option to this repositories workspace -> Should find the TS100 project.
 
 ## Developing with command line tools & building a release
 
 In the `workspace/TS100` folder there is a makefile that can be used to build the repository using command line tools.
 when running the `make` command, specify which model of the device & the language you would like to use.
 
-`make -J8 lang=EN model=TS80`
+`make -j8 lang=EN model=TS80`
 
 To build a release instead, run the build.sh script. This will update translations and also build every language for both TS100 and TS80 models.
 
 ## Updating languages
 
 To update the language translation files & associated font map, execute the `make_translation.py` code from the translations directory.
-

--- a/menu.md
+++ b/menu.md
@@ -26,7 +26,7 @@ Please calibrate your iron if you have any issues with the cutoff voltage.
 Note that cutoff messages can also be triggered by using a power supply that is too weak and fails under the load of the iron.
 This is more critical than before with the new cell count based cutout voltage.
 
-To calibrate your Iron:
+To calibrate your iron:
 
 1. Measure the input voltage with a multimeter and note it down.
 2. Connect the input to your iron.
@@ -51,11 +51,11 @@ Some tips will have an offset on their readings, to calibrate this out perform t
 4. Scroll down to the advanced menu, and then the temperature calibration
 5. Press the button to change the option (tip button)
 6. The display will start to scroll a warning message to check that the tip is at ambient temperature!
-7. Press the button near the tip of the iron to confirm.
+7. Press the button near the tip of the iron to confirm
 8. The display will go to "...." for a short period of time as the unit measures the tip temperature and the handle temperature and compares them
 9. The display will then go back to *TMP CAL*
 10. Calibration is done, just exit the settings menu as normal
-11. You're done. Enjoy your iron.
+11. You're done, enjoy your iron!
 
 ### Calibration of custom tip
 
@@ -63,11 +63,11 @@ There are two methods to calibrate the tip, the simple mode which requires boili
 
 Advanced mode is preffered.
 
-In simple mode you first need to have the tip at room temperature to start, and then when promped place the tip into a cup of boiling water, wait a few seconds and then press a button to confirm.
+In simple mode you first need to have the tip at room temperature to start, and then when prompted place the tip into a cup of boiling water, wait a few seconds and then press a button to confirm.
 
-In advanced mode, follow instructions on the screen, you will need to adjust the ranges to find two calibration points by measuing the tip temperature directly. This tends to be significantly more accurate.
+In advanced mode, follow instructions on the screen, you will need to adjust the ranges to find two calibration points by measuring the tip temperature directly. This tends to be significantly more accurate.
 
-If you do calibrate your own values for a tip because its missing from the menu or because you think the one in the menu is really wrong, raise an issue on github and I'm happy to look at adding it or revising the existing settings.
+If you do calibrate your own values for a tip because it's missing from the menu or because you think the one in the menu is really wrong, raise an issue on github and I'll be happy to look at adding it or revising the existing settings.
 
 
 ### Boost mode

--- a/power.md
+++ b/power.md
@@ -6,7 +6,7 @@ This *means* that the power proivded in the tip is 100% controlled by the supply
 
 Both irons at their simplest are just a resistor connected to your power source via a switch.
 
-When the switch is on, the power in the resistor is `Current (I) times Volts (V)`. 
+When the switch is on, the power in the resistor is `Current (I) times Volts (V)`.
 Current through the resistor is `Volts (V) divided by Resistance (R)`.
 Combining these two gives the common equation, power is `Volts (V) squared / Resistance (R)`.
 


### PR DESCRIPTION
Fixed up grammar, trailing newlines, missing end of lines, removed and added dots at ends of sentences where they should(n't) be.

Also fixed the make example which was using the wrong flag (J instead of j).

As a note History.md is not up to date with the current release.