### PR TITLE
Fixing QC 12V

### DIFF
--- a/workspace/TS100/Core/Src/hardware.cpp
+++ b/workspace/TS100/Core/Src/hardware.cpp
@@ -187,19 +187,15 @@ void seekQC(int16_t Vx10, uint16_t divisor) {
 		// No continuous mode, so QC2
 		QCMode = 2;
 		// Goto nearest
-		if (Vx10 > 10.5) {
+		if (Vx10 > 110) {
 			// request 12V
 			// D- = 0.6V, D+ = 0.6V
 			// Clamp PB3
-			HAL_GPIO_WritePin(GPIOB, GPIO_PIN_3, GPIO_PIN_RESET);// pull down D+
-			HAL_GPIO_WritePin(GPIOA, GPIO_PIN_10, GPIO_PIN_SET);
-			HAL_GPIO_WritePin(GPIOA, GPIO_PIN_8, GPIO_PIN_RESET);
+			QC_Seek12V();
 
 		} else {
 			// request 9V
-			HAL_GPIO_WritePin(GPIOB, GPIO_PIN_3, GPIO_PIN_SET);
-			HAL_GPIO_WritePin(GPIOA, GPIO_PIN_10, GPIO_PIN_SET);
-			HAL_GPIO_WritePin(GPIOA, GPIO_PIN_8, GPIO_PIN_RESET);
+			QC_Seek9V();
 		}
 	}
 #endif

--- a/workspace/TS100/Core/Src/hardware.cpp
+++ b/workspace/TS100/Core/Src/hardware.cpp
@@ -206,7 +206,7 @@ void startQC(uint16_t divisor) {
 	// negotiating as someone is feeding in hv
 	uint16_t vin = getInputVoltageX10(divisor, 1);
 	if (vin > 100) {
-		QCMode = 1;  // ALready at ~12V
+		QCMode = 1;  // Already at 12V, user has probably over-ridden this
 		return;
 	}
 	GPIO_InitTypeDef GPIO_InitStruct;


### PR DESCRIPTION
This is fairly simple one overall,
One of the voltage steps in the old code was in a bad order for QC, so on some devices 12V would drop out and on some it would work fine.
This is a bit of a cleanup as well :) 