### PR TITLE
Reduced stack usage in showBootLogoIfavailable().

### DIFF
--- a/workspace/TS100/Core/Inc/OLED.hpp
+++ b/workspace/TS100/Core/Inc/OLED.hpp
@@ -92,6 +92,8 @@ public:
 	static void drawSymbol(uint8_t symbolID);//Used for drawing symbols of a predictable width
 	static void drawArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
 			const uint8_t* ptr); //Draw an area, but y must be aligned on 0/8 offset
+	static void drawAreaSwapped(int16_t x, int8_t y, uint8_t wide, uint8_t height,
+			const uint8_t* ptr); //Draw an area, but y must be aligned on 0/8 offset
 	static void fillArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
 			const uint8_t value); //Fill an area, but y must be aligned on 0/8 offset
 	static void drawFilledRect(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1,

--- a/workspace/TS100/Core/Src/OLED.cpp
+++ b/workspace/TS100/Core/Src/OLED.cpp
@@ -262,6 +262,44 @@ void OLED::drawArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
 		}
 	}
 }
+
+// Draw an area, but y must be aligned on 0/8 offset
+// For data which has octets swapped in a 16-bit word.
+void OLED::drawAreaSwapped(int16_t x, int8_t y, uint8_t wide, uint8_t height,
+		const uint8_t *ptr) {
+	// Splat this from x->x+wide in two strides
+	if (x <= -wide)
+		return;  // cutoffleft
+	if (x > 96)
+		return;      // cutoff right
+
+	uint8_t visibleStart = 0;
+	uint8_t visibleEnd = wide;
+
+	// trimming to draw partials
+	if (x < 0) {
+		visibleStart -= x;  // subtract negative value == add absolute value
+	}
+	if (x + wide > 96) {
+		visibleEnd = 96 - x;
+	}
+
+	if (y == 0) {
+		// Splat first line of data
+		for (uint8_t xx = visibleStart; xx < visibleEnd; xx+=2) {
+			firstStripPtr[xx + x] = ptr[xx + 1];
+			firstStripPtr[xx + x + 1] = ptr[xx];
+		}
+	}
+	if (y == 8 || height == 16) {
+		// Splat the second line
+		for (uint8_t xx = visibleStart; xx < visibleEnd; xx+=2) {
+			secondStripPtr[x + xx] = ptr[xx + 1 + (height == 16 ? wide : 0)];
+			secondStripPtr[x + xx + 1] = ptr[xx + (height == 16 ? wide : 0)];
+		}
+	}
+}
+
 void OLED::fillArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
 		const uint8_t value) {
 	// Splat this from x->x+wide in two strides


### PR DESCRIPTION
Introduced new function OLED::drawAreaSwapped() for drawing images where
the octets are reveresed endianess in 16-bit words.


Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [x] The commit message makes sense
- [x] The changes have been tested locally
- [] Are there any breaking changes

* **What kind of change does this PR introduce?**
Fixes a TODO in the code:
`// TODO REDUCE STACK ON THIS ONE, USE DRAWING IN THE READ LOOP`

This change drastically reduces the stack usage of the showBootLogoIfavailable() function and cleans up the function.

* **What is the current behavior?**
showBootLogoIfavailable() uses 408 bytes of stack.

You can check this by compiling with the -fstack-usage flag in gcc. I then found the most stack consuming functions.
`$ cd workspace/TS100`
`$ find Objects -name "*.su" | xargs cat | sort -rnk2 | head
main.cpp:286:6:showBootLogoIfavailable()        408     static
Setup.c:33:6:Setup_HAL  136     static
main.cpp:49:5:main      136     static
stm32f1xx_hal_i2c.c:3425:6:HAL_I2C_EV_IRQHandler        72      static
stm32f1xx_hal_adc_ex.c:686:19:HAL_ADCEx_MultiModeStart_DMA      72      static
stm32f1xx_hal_i2c.c:728:19:HAL_I2C_Master_Receive       64      static
stm32f1xx_hal_adc_ex.c:812:19:HAL_ADCEx_MultiModeStop_DMA       64      static
stm32f1xx_hal_i2c.c:3142:19:HAL_I2C_Mem_Read_DMA        56      static
stm32f1xx_hal_i2c.c:3021:19:HAL_I2C_Mem_Write_DMA       56      static
stm32f1xx_hal_i2c.c:2579:19:HAL_I2C_Mem_Read    56      static
`



* **What is the new behavior (if this is a feature change)?**

The function now uses 16 bytes of stack:
`$ find Objects -name "*.su" | xargs cat | sort -rnk2 | grep showBootLogoIfavailable
main.cpp:290:6:showBootLogoIfavailable()        16      static`


* **Does this PR introduce a breaking change?**
No, the function is only used once during boot if a logo is programmed. Existing logos that have already been programmed will still be read by the new drawing function.

* **Other information**:
