### PR TITLE
Fix: Remove tip disconnection warning. Fix leading zeros (again)

### DIFF
--- a/workspace/TS100/Core/Src/GUIThread.cpp
+++ b/workspace/TS100/Core/Src/GUIThread.cpp
@@ -453,7 +453,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
 	 * --> Double button to exit
 	 */
 	bool boostModeOn = false;
-	uint8_t badTipCounter = 0;
+
 	uint32_t sleepThres = 0;
 	if (systemSettings.SleepTime < 6)
 		sleepThres = systemSettings.SleepTime * 10 * 100;
@@ -502,11 +502,6 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
 		OLED::clearScreen();
 		OLED::setFont(0);
 		uint16_t tipTemp = getTipRawTemp(0);
-		if (tipTemp > 32700) {
-			badTipCounter++; // Use a counter so that error has to persist for > 1 second continuous so that peak errors dont trip it
-		} else {
-			badTipCounter = 0;
-		}
 		//Draw in the screen details
 		if (systemSettings.detailedSoldering) {
 			OLED::setFont(1);
@@ -563,15 +558,6 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
 
 				gui_drawBatteryIcon();
 			}
-		}
-
-		if (badTipCounter > 128) {
-			OLED::print(BadTipString);
-			OLED::refresh();
-			currentTempTargetDegC = 0;
-			waitForButtonPress();
-			currentTempTargetDegC = 0;
-			return;
 		}
 		OLED::refresh();
 

--- a/workspace/TS100/Core/Src/OLED.cpp
+++ b/workspace/TS100/Core/Src/OLED.cpp
@@ -163,10 +163,10 @@ uint8_t OLED::getFont() {
 	else
 		return 0;
 }
-inline void stripLeaderZeros(char *buffer) {
+inline void stripLeaderZeros(char *buffer, uint8_t places) {
 	//Removing the leading zero's by swapping them to SymbolSpace
 	// Stop 1 short so that we dont blank entire number if its zero
-	for (int i = 0; i < 6; i++) {
+	for (int i = 0; i < (places-1); i++) {
 		if (buffer[i] == 2) {
 			buffer[i] = SymbolSpace[0];
 		} else {
@@ -204,7 +204,7 @@ void OLED::printNumber(uint16_t number, uint8_t places, bool noLeaderZeros) {
 
 	buffer[0] = 2 + number % 10;
 	if (noLeaderZeros)
-		stripLeaderZeros(buffer);
+		stripLeaderZeros(buffer, places);
 	print(buffer);
 }
 
@@ -286,14 +286,14 @@ void OLED::drawAreaSwapped(int16_t x, int8_t y, uint8_t wide, uint8_t height,
 
 	if (y == 0) {
 		// Splat first line of data
-		for (uint8_t xx = visibleStart; xx < visibleEnd; xx+=2) {
+		for (uint8_t xx = visibleStart; xx < visibleEnd; xx += 2) {
 			firstStripPtr[xx + x] = ptr[xx + 1];
 			firstStripPtr[xx + x + 1] = ptr[xx];
 		}
 	}
 	if (y == 8 || height == 16) {
 		// Splat the second line
-		for (uint8_t xx = visibleStart; xx < visibleEnd; xx+=2) {
+		for (uint8_t xx = visibleStart; xx < visibleEnd; xx += 2) {
 			secondStripPtr[x + xx] = ptr[xx + 1 + (height == 16 ? wide : 0)];
 			secondStripPtr[x + xx + 1] = ptr[xx + (height == 16 ? wide : 0)];
 		}

--- a/workspace/TS100/Core/Src/TipThermoModel.cpp
+++ b/workspace/TS100/Core/Src/TipThermoModel.cpp
@@ -119,3 +119,10 @@ uint32_t TipThermoModel::getTipInF(bool sampleNow) {
 	currentTipTempInF += convertCtoF(getHandleTemperature() / 10); //Add handle offset
 	return currentTipTempInF;
 }
+
+uint32_t TipThermoModel::getTipMaxInC() {
+	uint32_t maximumTipTemp = TipThermoModel::convertTipRawADCToDegC(
+			0x7FFF - 10);
+	maximumTipTemp += getHandleTemperature() / 10; //Add handle offset
+	return maximumTipTemp;
+}

--- a/workspace/TS100/Core/Src/TipThermoModel.h
+++ b/workspace/TS100/Core/Src/TipThermoModel.h
@@ -12,9 +12,11 @@
 class TipThermoModel {
 public:
 	//These are the main two functions
-	static uint32_t getTipInC(bool sampleNow=false);
-	static uint32_t getTipInF(bool sampleNow=false);
+	static uint32_t getTipInC(bool sampleNow = false);
+	static uint32_t getTipInF(bool sampleNow = false);
 
+	//Calculates the maximum temperature can can be read by the ADC range
+	static uint32_t getTipMaxInC();
 
 	static uint32_t convertTipRawADCToDegC(uint16_t rawADC);
 	static uint32_t convertTipRawADCToDegF(uint16_t rawADC);

--- a/workspace/TS100/Core/Src/main.cpp
+++ b/workspace/TS100/Core/Src/main.cpp
@@ -138,6 +138,9 @@ void startPIDTask(void const *argument __unused) {
 					//Maximum allowed output
 					currentTempTargetDegC = (450);
 				}
+				if (currentTempTargetDegC > TipThermoModel::getTipMaxInC()) {
+					currentTempTargetDegC = TipThermoModel::getTipMaxInC();
+				}
 				// Convert the current tip to degree's C
 
 				// As we get close to our target, temp noise causes the system
@@ -190,7 +193,8 @@ void startPIDTask(void const *argument __unused) {
 			}
 #endif
 
-			if (systemSettings.powerLimitEnable && x10WattsOut > (systemSettings.powerLimit * 10))
+			if (systemSettings.powerLimitEnable
+					&& x10WattsOut > (systemSettings.powerLimit * 10))
 				setTipX10Watts(systemSettings.powerLimit * 10);
 			else
 				setTipX10Watts(x10WattsOut);
@@ -289,17 +293,17 @@ void startMOVTask(void const *argument __unused) {
 
 /* The header value is (0xAA,0x55,0xF0,0x0D) but is stored in little endian 16
  * bits words on the flash */
-const uint8_t LOGO_HEADER_VALUE[] = {0x55, 0xAA, 0x0D, 0xF0};
+const uint8_t LOGO_HEADER_VALUE[] = { 0x55, 0xAA, 0x0D, 0xF0 };
 
 bool showBootLogoIfavailable() {
-    uint8_t *header = (uint8_t*) (FLASH_LOGOADDR);
+	uint8_t *header = (uint8_t*) (FLASH_LOGOADDR);
 
 	// check if the header is correct. 
-    for(int i = 0; i < 4; i++) {
-        if(header[i] != LOGO_HEADER_VALUE[i]) {
-            return false;
-        }
-    }
+	for (int i = 0; i < 4; i++) {
+		if (header[i] != LOGO_HEADER_VALUE[i]) {
+			return false;
+		}
+	}
 
 	OLED::drawAreaSwapped(0, 0, 96, 16, (uint8_t*) (FLASH_LOGOADDR + 4));
 	OLED::refresh();


### PR DESCRIPTION
Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [x] The commit message makes sense
- [x] The changes have been tested locally
- [ ] Are there any breaking changes

* **What kind of change does this PR introduce?**
(Bug fix, feature, docs update, ...)
Fix:
Remove tip disconnection warning. 
Fix leading zeros (again)

Closes #551 

* **What is the current behavior?**

Setting the target temperature too high can cause the tip disconnection to trigger and stop the iron heating.

Also fixed missing zeros in some of the number displays.
