### PR TITLE
Clearing screen before showing settings reset alert

### DIFF
--- a/workspace/TS100/Core/Src/GUIThread.cpp
+++ b/workspace/TS100/Core/Src/GUIThread.cpp
@@ -699,6 +699,7 @@ void startGUITask(void const *argument __unused) {
 
 	if (settingsWereReset) {
 		//Display alert settings were reset
+		OLED::clearScreen();
 		OLED::setFont(1);
 		OLED::setCursor(0, 0);
 		OLED::print(SettingsResetMessage);


### PR DESCRIPTION
It's needed because as of now the alert overlaps the custom bootlogo


Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [X] The commit message makes sense
- [ ] The changes have been tested locally
- [ ] Are there any breaking changes

* **What kind of change does this PR introduce?**
(Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?**
(You can also link to an open issue here)
The alert overlaps with a custom boot logo


* **What is the new behavior (if this is a feature change)?**
The screen is cleared before showing the alert


* **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Fix not tested locally because I don't have a full stm32 toolchain on my pc, but it should be a pretty trivial fix