### PR TITLE
bugfix - git hash returns tags (if set) instead the short hash

### DIFF
--- a/Translation Editor/make_translation.py
+++ b/Translation Editor/make_translation.py
@@ -503,7 +503,8 @@ def readVersion():
                     if line: 
                         version = line[0]
                         try: version += "."+ subprocess.check_output(
-                            ["git","describe", "--always"]).strip().decode('ascii').upper()
+                            ["git","rev-parse", "--short=7", "HEAD"]).strip().decode('ascii').upper()
+                            # --short=7: the shorted hash with 7 digits. Increase/decrease if needed!
                         except OSError: version += " git"
         finally: 
             if version_file: 


### PR DESCRIPTION
using "git rev-parse --short=7 HEAD" to be sure we always get the commit hash.