### PR TITLE
Fix scrollbar thumb position for long menus

### DIFF
--- a/workspace/TS100/Core/Src/gui.cpp
+++ b/workspace/TS100/Core/Src/gui.cpp
@@ -935,7 +935,7 @@ void gui_Menu(const menuitem *menu) {
 			OLED::clearScreen();
 			menu[currentScreen].draw.func();
 			uint8_t indicatorHeight = OLED_HEIGHT / scrollContentSize;
-			uint8_t position = currentScreen * indicatorHeight;
+			uint8_t position = OLED_HEIGHT * currentScreen / scrollContentSize;
 			OLED::drawScrollIndicator(position, indicatorHeight);
 			lastOffset = -1;
 			lcdRefresh = true;


### PR DESCRIPTION
Advanced settings menu has 9 entries so the thumb ends up being one
pixel high and on the 9th menu it ends up being closer to the middle of
the screen rather than the end. This patch fixes it.
