### PR TITLE
Fix FTBFS due to LTO being more sensitive to file order

### DIFF
--- a/workspace/TS100/Makefile
+++ b/workspace/TS100/Makefile
@@ -95,7 +95,9 @@ LINKER_FLAGS=-Wl,--gc-sections 		\
 			-Wl,--wrap=free \
 			-o$(OUT_HEXFILE).elf 	\
 			-Wl,-Map=$(OUT_HEXFILE).map \
-			-lm -Wl,--undefined=vTaskSwitchContext \
+			-lm \
+			-Wl,--undefined=vTaskSwitchContext \
+			-Wl,--undefined=pxCurrentTCB \
 			-Wl,--defsym=__FLASH_SIZE__=$(flash_size) \
 			-Wl,--defsym=__BOOTLDR_SIZE__=$(bootldr_size) \
 			--specs=nano.specs

--- a/workspace/TS100/Makefile
+++ b/workspace/TS100/Makefile
@@ -10,7 +10,6 @@ endif
 # Discover the source files to build
 SOURCE := $(shell find . -type f -name '*.c')
 SOURCE_CPP := $(shell find . -type f -name '*.cpp')
-SOURCES := $(shell find . -type f -name '*.c*')
 S_SRCS := $(shell find . -type f -name '*.s') 
 
 APP_INC_DIR = ./Core/Inc
@@ -47,7 +46,7 @@ HEXFILE_DIR=Hexfile
 OUTPUT_DIR=Objects
 
 # code optimisation ------------------------------------------------------------
-OPTIM=-Os -flto -ffat-lto-objects -finline-small-functions -findirect-inlining -fdiagnostics-color -ffunction-sections -fdata-sections
+OPTIM=-Os -flto -finline-small-functions -findirect-inlining -fdiagnostics-color -ffunction-sections -fdata-sections
 
 flash_size=64k
 bootldr_size=0x4000
@@ -64,7 +63,7 @@ DEBUG=-g3
 # Without debug code
 #DEBUG=
 
-	
+
 # libs -------------------------------------------------------------------------
 LIBS=
 


### PR DESCRIPTION
When a symbol is used from inline assembly, LTO compiling and linking
process becomes more picky with regard to the order of compile/linking
units.

Specifically, when FreeRTOS/Source/portable/GCC/ARM_CM3/port.c comes
before FreeRTOS/Source/tasks.c in find results, the build fails with
undefined reference to `pxCurrentTCB' error.

To workaround the issue, do the same as we already have for
vTaskSwitchContext.

Note: different order affects resulting binary (.text section) size:
39924 with the wrong order and 39884 with the correct.

Fixes #685.


Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [] The commit message makes sense
- [] The changes have been tested locally
- [] Are there any breaking changes

* **What kind of change does this PR introduce?**
(Bug fix, feature, docs update, ...)



* **What is the current behavior?**
(You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?**
(What changes might users need to make in their application due to this PR?)


* **Other information**:
