### PR TITLE
[PoC] limit maximum power more efficiently

### DIFF
--- a/workspace/TS100/Core/BSP/BSP.h
+++ b/workspace/TS100/Core/BSP/BSP.h
@@ -1,9 +1,10 @@
+#include <stdint.h>
+#include <stdbool.h>
 #include "BSP_Flash.h"
 #include "BSP_Power.h"
 #include "BSP_QC.h"
 #include "Defines.h"
 #include "Model_Config.h"
-#include "stdint.h"
 /*
  * BSP.h -- Board Support
  *
@@ -16,10 +17,18 @@
 extern "C" {
 #endif
 
+// maximum htim2 PWM value
+extern const uint16_t powerPWM;
+// htim2.Init.Period, the full PWM cycle
+extern uint16_t totalPWM;
+
 // Called first thing in main() to init the hardware
 void preRToSInit();
 // Called once the RToS has started for any extra work
 void postRToSInit();
+
+// Called once from preRToSInit()
+void BSPInit(void);
 
 // Called to reset the hardware watchdog unit
 void resetWatchdog();
@@ -31,6 +40,9 @@ uint16_t getHandleTemperature();
 uint16_t getTipRawTemp(uint8_t refresh);
 // Returns the main DC input voltage, using the adjustable divisor + sample flag
 uint16_t getInputVoltageX10(uint16_t divisor, uint8_t sample);
+// Switch to the most suitable PWM freq given the desired period;
+// returns true if the switch was performed and totalPWM changed
+bool tryBetterPWM(uint8_t pwm);
 
 // Readers for the two buttons
 // !! Returns 1 if held down, 0 if released

--- a/workspace/TS100/Core/BSP/Miniware/Setup.c
+++ b/workspace/TS100/Core/BSP/Miniware/Setup.c
@@ -315,13 +315,15 @@ static void MX_TIM2_Init(void) {
 	// Timer 2 is fairly slow as its being used to run the PWM and trigger the ADC
 	// in the PWM off time.
 	htim2.Instance = TIM2;
-	htim2.Init.Prescaler = 4000; //1mhz tick rate/800 = 1.25 KHz tick rate
+	// dummy value, will be reconfigured by BSPInit()
+	htim2.Init.Prescaler = 2000; // 2 MHz timer clock/2000 = 1 kHz tick rate
 
 	// pwm out is 10k from tim3, we want to run our PWM at around 10hz or slower on the output stage
-	// These values give a rate of around 8Hz
+	// These values give a rate of around 3.5 Hz for "fast" mode and 1.84 Hz for "slow"
 	htim2.Init.CounterMode = TIM_COUNTERMODE_UP;
-	htim2.Init.Period = 255 + 17;
-	htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV4;  // 4mhz before divide
+	// dummy value, will be reconfigured by BSPInit()
+	htim2.Init.Period = 255 + 17 * 2;
+	htim2.Init.ClockDivision = TIM_CLOCKDIVISION_DIV4;  // 8 MHz (x2 APB1) before divide
 	htim2.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
 	htim2.Init.RepetitionCounter = 0;
 	HAL_TIM_Base_Init(&htim2);
@@ -337,7 +339,8 @@ static void MX_TIM2_Init(void) {
 	HAL_TIMEx_MasterConfigSynchronization(&htim2, &sMasterConfig);
 
 	sConfigOC.OCMode = TIM_OCMODE_PWM1;
-	sConfigOC.Pulse = 255 + 13;  //13 -> Delay of 5ms
+	// dummy value, will be reconfigured by BSPInit()
+	sConfigOC.Pulse = 255 + 13 * 2;  // 13 -> Delay of 7 ms
 	//255 is the largest time period of the drive signal, and then offset ADC sample to be a bit delayed after this
 	/*
 	 * It takes 4 milliseconds for output to be stable after PWM turns off.

--- a/workspace/TS100/Core/BSP/Miniware/preRTOS.cpp
+++ b/workspace/TS100/Core/BSP/Miniware/preRTOS.cpp
@@ -17,6 +17,7 @@ void preRToSInit() {
 	 */
 	HAL_Init();
 	Setup_HAL();  // Setup all the HAL objects
+	BSPInit();
 #ifdef I2C_SOFT
 	I2CBB::init();
 #endif

--- a/workspace/TS100/Core/Inc/power.hpp
+++ b/workspace/TS100/Core/Inc/power.hpp
@@ -25,6 +25,4 @@ extern expMovingAverage<uint32_t, wattHistoryFilter> x10WattHistory;
 int32_t tempToX10Watts(int32_t rawTemp);
 void setTipX10Watts(int32_t mw);
 uint8_t X10WattsToPWM(int32_t milliWatts, uint8_t sample = 0);
-int32_t PWMToX10Watts(uint8_t pwm, uint8_t sample = 0);
-uint32_t availableW10(uint8_t sample) ;
 #endif /* POWER_HPP_ */

--- a/workspace/TS100/configuration.h
+++ b/workspace/TS100/configuration.h
@@ -131,7 +131,7 @@
 
 #ifdef MODEL_TS100
 const int32_t tipMass = 45; // X10 watts to raise 1 deg C in 1 second
-const uint8_t tipResistance = 85; //x10 ohms, 8.5 typical for ts100, 4.5 typical for ts80
+const uint8_t tipResistance = 75; //x10 ohms, 7.5 typical for ts100 tips
 #endif
 
 #ifdef MODEL_TS80


### PR DESCRIPTION
With this a TS-I tip is usable with a small netbook 19 V / 30 W PSU with
power limit set to 40 W (38.9 W is reported during the heating up
stage). Without this the device just reboots on attempt to turn on the
heater (unless the power limit is set to 10 or even 5 W).

This code doesn't affect maximum power available and allows up to 73 W
when a beefy 24 V / 96 W PSU is used.

Should be useful for all models, not just TS100.

The fixed comments are based on calculations, not measurements!

Supposed to fix #693.


Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [] The changes have been tested locally
- [] There are no breaking changes

* **What kind of change does this PR introduce?**
(Bug fix, feature, docs update, ...)



* **What is the current behavior?**
(You can also link to an open issue here)

* **What is the new behavior (if this is a feature change)?**

* **Other information**:
