### PR TITLE
Fix BadTipString in Italian translation

### DIFF
--- a/Translation Editor/translation_it.json
+++ b/Translation Editor/translation_it.json
@@ -10,7 +10,7 @@
 		"UndervoltageString": "DC INSUFFICIENTE",
 		"InputVoltageString": "V ingresso:",
 		"WarningTipTempString": "Temp punta:",
-		"BadTipString": "PUNTA NO",
+		"BadTipString": "PUNTA KO",
 		"SleepingSimpleString": "Zzz ",
 		"SleepingAdvancedString": "Standby",
 		"WarningSimpleString": "HOT!",


### PR DESCRIPTION
Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [X] The changes have been tested locally
- [X] There are no breaking changes

* **What kind of change does this PR introduce?**
Small fix in Italian translation

"PUNTA NO" means "no tip", whereas "KO" means not ok
