### PR TITLE
Locking Mode

### DIFF
--- a/Translation Editor/translation_bg.json
+++ b/Translation Editor/translation_bg.json
@@ -23,7 +23,10 @@
 		"OffString": "Изкл.",
 		"ResetOKMessage": "Нулиране завършено",
 		"YourGainMessage": "Усилване:",
-		"SettingsResetMessage": "Настройките бяха\nнулирани!"
+		"SettingsResetMessage": "Настройките бяха\nнулирани!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -34,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -68,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Източник",
 				"захранване"
 			],
 			"desc": "Източник на захранване. Минимално напрежение. <DC 10V> <S 3.3V за клетка>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Темп.",
 				"сън"
 			],
 			"desc": "Температура при режим \"сън\" <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Време",
 				"сън"
 			],
 			"desc": "Включване в режим \"сън\" след: <Минути/Секунди>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Време",
 				"изкл."
 			],
 			"desc": "Изключване след <Минути>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Усещане",
 				"за движение"
 			],
 			"desc": "Усещане за движение <0.Изключено 1.Слабо 9.Силно>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Единици за",
 				"температура"
 			],
 			"desc": "Единици за температура <C=Целзии F=Фаренхайт>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Детайлен",
 				"екран в покой"
 			],
 			"desc": "Покажи детайлна информация със ситен шрифт на екрана в режим на покой."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Ориентация",
 				"на дисплея"
 			],
 			"desc": "Ориентация на дисплея <A. Автоматично L. Лява Ръка R. Дясна Ръка>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Турбо",
 				"темп."
 			],
 			"desc": "Температура за \"турбо\" режим"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Автоматичен",
 				"работен режим"
 			],
 			"desc": "Режим на поялника при включване на захранването. T=Работен, S=Сън, F=Изключен"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Мигай при",
 				"топъл поялник"
 			],
 			"desc": "След изключване от работен режим, индикатора за температура да мига докато човката на поялника все още е топла"
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Калибриране",
 				"температура?"
 			],
 			"desc": "Калибриране на температурата"
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Фабрични",
 				"настройки?"
 			],
 			"desc": "Връщане на фабрични настройки"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Калибриране",
 				"напрежение?"
 			],
 			"desc": "Калибриране на входното напрежение. Задръжте бутонa за изход"
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Детайлен",
 				"работен екран"
 			],
 			"desc": "Детайлна информация в работен режим при запояване"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Скорост",
 				"на текста"
 			],
 			"desc": "Скорост на движение на този текст"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Модел",
 				"на връх"
 			],
 			"desc": "Избор на модел на връх"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Бърза",
 				"калибрация"
 			],
 			"desc": "Бърза калибрация с използване на гореща вода"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Прецизна",
 				"калибрация"
 			],
 			"desc": "Прецизна калибрация с използване на термо-двойка на върха на поялника"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Мощност на",
 				"захранване"
 			],
 			"desc": "Мощност на избраното захранване"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Лимит на",
 				"мощност"
 			],
 			"desc": "Максимална мощност на поялника <W>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Размяна",
 				"бутони +-?"
 			],
 			"desc": "Обръщане на бутоните \"+\" и \"-\" за промяна на температурата на върха на поялника"
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Промяна T",
 				"бързо?"
 			],
 			"desc": "Промяна на температура при бързо натискане на бутон!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Промяна Т",
 				"задържане?"
 			],
 			"desc": "Промяна на температура при задържане на бутон!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Захранващ",
 				"импулс"
 			],
 			"desc": "Поддържане на интензивност на захранващия импулс"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Промяна",
 				"сила връх"
 			],
 			"desc": "Усилване на върха на поялника"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_cs.json
+++ b/Translation Editor/translation_cs.json
@@ -23,7 +23,10 @@
 		"OffString": "Vyp",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Zisk:",
-		"SettingsResetMessage": "Tov. nas. obnov."
+		"SettingsResetMessage": "Tov. nas. obnov.",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "P",
@@ -34,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -68,112 +74,112 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Zdroj",
 				"napájení"
 			],
 			"desc": "Při nižším napětí ukončí pájení <DC=10V, ?S=?x3.3V pro LiPo, LiIon...>."
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Teplota v",
 				"r. spánku"
 			],
 			"desc": "Teplota v režimu spánku."
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Čas do",
 				"r. spánku"
 			],
 			"desc": "Čas do režimu spánku <Minut/Sekund>."
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Čas do",
 				"vypnutí"
 			],
 			"desc": "Čas do automatického vypnutí <Minut>."
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Citlivost",
 				"det. pohybu"
 			],
 			"desc": "Citlivost detekce pohybu <0=Vyp, 1=Min, ... 9=Max>."
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Jednotky",
 				"teploty"
 			],
 			"desc": "Jednotky měření teploty <C=Celsius, F=Fahrenheit>."
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Podrobnosti",
 				"na vých. obr."
 			],
 			"desc": "Zobrazit podrobnosti na výchozí obrazovce?"
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Orientace",
 				"obrazovky"
 			],
 			"desc": "Orientace obrazovky <A=Auto, L=Levák, P=Pravák>."
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Teplota v",
 				"r. boost"
 			],
 			"desc": "Teplota v režimu boost."
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Automatický",
 				"start"
 			],
 			"desc": "Při startu ihned nahřát hrot?"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Blikáni při",
 				"chladnutí"
 			],
 			"desc": "Blikání teploty při chladnutí, dokud je hrot horký?"
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibrovat",
 				"teplotu?"
 			],
 			"desc": "Kalibrace měření teploty."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Tovární",
 				"nastavení?"
 			],
 			"desc": "Obnovení továrního nastavení."
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibrovat",
 				"vstupní napětí?"
 			],
 			"desc": "Kalibrace vstupního napětí. Tlačítky uprav, podržením potvrď."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Podrobnosti",
 				"při pájení"
 			],
 			"desc": "Zobrazit podrobnosti při pájení?"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Rychlost",
 				"popisků"
 			],
@@ -248,6 +254,13 @@
 				"zisk hr."
 			],
 			"desc": "Zisk hrotu (měření)"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_da.json
+++ b/Translation Editor/translation_da.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "TIP DISCONNECTED",
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "H",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "D",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "S"
+		"SettingStartNoneChar": "S",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -233,7 +241,7 @@
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
+		"PowerPulsePower": {
 			"text2": [
 				"Power",
 				"Pulse W"
@@ -246,6 +254,13 @@
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_de.json
+++ b/Translation Editor/translation_de.json
@@ -24,7 +24,10 @@
 		"OffString": "Aus",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your Gain:",
-		"SettingsResetMessage": "Einstellungen\nzurück gesetzt!"
+		"SettingsResetMessage": "Einstellungen\nzurück gesetzt!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -35,7 +38,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -69,187 +75,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Spannungs-",
 				"quelle"
 			],
 			"desc": "Spannungsquelle (Abschaltspannung) <DC=10V, nS=n*3.3V für n LiIon-Zellen>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Ruhetemp-",
 				"eratur"
 			],
 			"desc": "Ruhetemperatur"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Ruhever-",
 				"zögerung"
 			],
 			"desc": "Ruhemodus nach <Sekunden/Minuten>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Abschalt-",
 				"zeit"
 			],
 			"desc": "Abschalten nach <Minuten>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Bewegungs-",
 				"empfindlichk."
 			],
 			"desc": "Bewegungsempfindlichkeit <0=Aus, 1=Minimal ... 9=Maximal>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Temperatur-",
 				"einheit"
 			],
 			"desc": "Temperatureinheit <C=Celsius, F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Detaillierte",
 				"Ruheansicht"
 			],
 			"desc": "Detaillierte Anzeige im Ruhemodus"
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Anzeige-",
 				"ausrichtung"
 			],
 			"desc": "Ausrichtung der Anzeige <A=Automatisch, L=Linkshändig, R=Rechtshändig>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Boosttemp-",
 				"eratur"
 			],
 			"desc": "Temperatur im Boostmodus  (In der eingestellten Einheit)"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Start im",
 				"Lötmodus?"
 			],
 			"desc": "Automatischer Start-Modus beim Einschalten der Spannungsversorgung. <T=Lötmodus S=Ruhezustand F=Aus>"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Abkühl-",
 				"blinken?"
 			],
 			"desc": "Blinkende Temperaturanzeige beim Abkühlen, solange heiß ist."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Temperatur",
 				"kalibrieren?"
 			],
 			"desc": "Kalibrierung der Lötspitzentemperatur"
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Einstellungen",
 				"zurücksetzen?"
 			],
 			"desc": "Einstellungen auf werkseinstellungen zurück setzen"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Eingangsspannung",
 				"kalibrieren?"
 			],
 			"desc": "Kalibrierung der Eingangsspannung. Kurzer Tastendruck zum Einstellen, langer Tastendruck zum Verlassen."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Detaillierte",
 				"Lötansicht"
 			],
 			"desc": "Detaillierte Anzeige im Lötmodus"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Scroll-",
 				"geschw."
 			],
 			"desc": "Scrollgeschwindigkeit der Texte <S=Langsam F=Schnell>"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Löt-",
 				"spitze"
 			],
 			"desc": "Auswahl der Lötspitze"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Einfache",
 				"Kalibrierung"
 			],
 			"desc": "Einfache Kalibrierung mittels heißem Wasser"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Erweiterte",
 				"Kalibrierung"
 			],
 			"desc": "Erweiterte Kalibrierung mittels eines Thermoelements an der Lötspitze"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Leistungs-",
 				"Aufnahme"
 			],
 			"desc": "Leistungsaufnahme der verwendeten Spannungsversorgung"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Leistungs-",
 				"Limit"
 			],
 			"desc": "Maximale aufnahme der Lötspitze <Watt>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Taste +-",
 				"Umkehren?"
 			],
 			"desc": "Temperatur-Änderungs-Tasten-Belegung Plus-Minus umkehren?"
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"T. Schritt",
 				"Taste kurz?"
 			],
 			"desc": "Temperaturwechselschritte bei kurzem Tastendruck!"
-		}
-		,
+		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"T. Schritt",
 				"Taste Lang?"
 			],
 			"desc": "Temperaturwechselschritte bei langem Tastendruck!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_en.json
+++ b/Translation Editor/translation_en.json
@@ -24,7 +24,10 @@
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!"
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -35,7 +38,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -249,6 +255,13 @@
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+						"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_es.json
+++ b/Translation Editor/translation_es.json
@@ -23,7 +23,10 @@
 		"OffString": " No",
 		"ResetOKMessage": "Hecho.       ",
 		"YourGainMessage": "Gananc.:",
-		"SettingsResetMessage": "Ajustes borrados"
+		"SettingsResetMessage": "Ajustes borrados",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -34,7 +37,10 @@
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "R",
 		"SettingStartSleepOffChar": "F",
-		"SettingStartNoneChar": "N"
+		"SettingStartNoneChar": "N",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -68,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Fuente",
 				"de energía"
 			],
 			"desc": "Elige el tipo de fuente para limitar el voltaje <DC 10V> <S 3,3V por pila, ilimitado>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Temperatura",
 				"en reposo"
 			],
 			"desc": "Temperatura de la punta en reposo."
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Entrar",
 				"en reposo"
 			],
 			"desc": "Tiempo de inactividad para entrar en reposo <min/seg>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Tiempo de",
 				"apagado"
 			],
 			"desc": "Tiempo de inactividad para apagarse <en minutos>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Detección de",
 				"movimiento"
 			],
 			"desc": "Tiempo de reacción al agarrar <0=no 1=menos sensible 9=más sensible>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Unidad de",
 				"temperatura"
 			],
 			"desc": "Unidad de temperatura <C=centígrados F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Info extra en",
 				"modo reposo"
 			],
 			"desc": "Muestra información detallada en letra pequeña al reposar."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Orientación",
 				"de pantalla"
 			],
 			"desc": "Orientación de la pantalla <A=automático I=zurdo D=diestro>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Ajustar la",
 				"temp. extra"
 			],
 			"desc": "Temperatura momentánea que se alcanza al apretar el botón del modo extra."
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Calentar",
 				"al enchufar"
 			],
 			"desc": "Se calienta él solo al arrancar <S=entrar en modo soldar R=solo entrar en reposo F=en reposo pero mantiene la punta fría N=no>"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Parpadear",
 				"al enfriar"
 			],
 			"desc": "La temperatura en pantalla parpadea mientras la punta siga caliente."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Calibrar temp.",
 				"de la punta"
 			],
 			"desc": "Calibra la desviación térmica de la punta."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Volver a ajustes",
 				"de fábrica"
 			],
 			"desc": "Restablece todos los ajustes a los valores originales."
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Calibrar voltaje",
 				"de entrada"
 			],
 			"desc": "Calibra VIN. Ajusta con ambos botones y mantén pulsado para salir."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Info extra",
 				"al soldar"
 			],
 			"desc": "Muestra más datos por pantalla cuando se está soldando."
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Velocidad",
 				"del texto"
 			],
 			"desc": "Velocidad de desplazamiento del texto <R=rápida L=lenta>"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Modelo de",
 				"punta"
 			],
 			"desc": "Elegir el modelo de punta actual."
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Calibración",
 				"simple"
 			],
 			"desc": "Calibración simple con agua caliente."
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Calibración",
 				"avanzada"
 			],
 			"desc": "Calibrar con un termopar en la punta; más difícil."
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Potencia de",
 				"entrada"
 			],
 			"desc": "Potencia en vatios del adaptador de corriente utilizado."
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Ajustar la",
 				"potenc. máx."
 			],
 			"desc": "Elige el límite de potencia máxima del soldador <en vatios>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Invertir",
 				"botones +/-"
 			],
 			"desc": "Intercambia las funciones de subir y bajar la temperatura de los botones +/- para que funcionen al revés."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Cambio temp.",
 				"puls. cortas"
 			],
 			"desc": "Subir y bajar X grados de temperatura con cada pulsación corta de los botones +/-."
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Cambio temp.",
 				"puls. largas"
 			],
 			"desc": "Subir y bajar X grados de temperatura con cada pulsación larga de los botones +/-."
 		},
 		"PowerPulsePower": {
-						"text2": [
+			"text2": [
 				"Pulsos bat.",
 				"constantes"
 			],
 			"desc": "Aplica unos pulsos necesarios para mantener encendidas ciertas baterías portátiles. En vatios."
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Ajustar ganancia",
 				"de punta"
 			],
 			"desc": "Modificar el valor de ganancia de la punta."
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_fi.json
+++ b/Translation Editor/translation_fi.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "KÄRKI ON IRTI",
 		"SolderingAdvancedPowerPrompt": "Teho: ",
 		"OffString": "OFF",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "O",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Virtalähde",
 				"DC"
 			],
 			"desc": "Käytettävä virtalähde. Asettaa katkaisujänniteen. <DC 10V, 3S=9.9V, 4S=13.2V, 5S=16.5V, 6S=19.8V>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Lepotilan",
 				"lämpötila"
 			],
 			"desc": "Lepotilan lämpötila. <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Lepotilan",
 				"viive"
 			],
 			"desc": "Lepotilan viive. <minuuttia/sekuntia>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Sammutus",
 				"viive"
 			],
 			"desc": "Automaattisen sammutuksen aikaviive. <minuuttia>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Liikkeen",
 				"herkkyys"
 			],
 			"desc": "Liikkeentunnistuksen herkkyys. <0=pois, 1=epäherkin, 9=herkin>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Lämpötilan",
 				"yksikkö"
 			],
 			"desc": "Lämpötilan yksikkö. <C=celsius, F=fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Tiedot",
 				"lepotilassa"
 			],
 			"desc": "Näyttää yksityiskohtaisemmat tiedot lepotilassa."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Näytön",
 				"kierto"
 			],
 			"desc": "Näytön kierto. <A=automaattinen O=oikeakätinen V=vasenkätinen>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Tehostus-",
 				"lämpötila"
 			],
 			"desc": "Tehostustilan lämpötila"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Autom.",
 				"käynnistys"
 			],
 			"desc": "Käynnistää virrat kytkettäessä juotostilan automaattisesti. T=juotostila, S=Lepotila, F=Ei käytössä"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Jäähdytyksen",
 				"vilkutus"
 			],
 			"desc": "Vilkuttaa jäähtyessä juotoskärjen lämpötilaa sen ollessa vielä vaarallisen kuuma."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibroi",
 				"lämpötila?"
 			],
 			"desc": "Kalibroi kärjen lämpötilaeron."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Palauta",
 				"tehdasasetukset?"
 			],
 			"desc": "Palauta kaikki asetukset oletusarvoihin."
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibroi",
 				"tulojännite?"
 			],
 			"desc": "Tulojännitten kalibrointi (VIN). Painikkeilla säädetään ja pitkään painamalla poistutaan."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Tarkempi",
 				"juotosnäyttö"
 			],
 			"desc": "Näyttää yksityiskohtaisemmat tiedot juotostilassa."
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Tietojen",
 				"näyttönopeus"
 			],
 			"desc": "Näiden selitetekstien vieritysnopeus."
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Tip",
 				"Model"
 			],
 			"desc": "Tip Model selection"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Simple",
 				"Calibration"
 			],
 			"desc": "Simple Calibration using Hot water"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Advanced",
 				"Calibration"
 			],
 			"desc": "Advanced calibration using thermocouple on the tip"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Wattage"
 			],
 			"desc": "Power Wattage of the power adapter used"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_fr.json
+++ b/Translation Editor/translation_fr.json
@@ -16,12 +16,17 @@
 		"WarningSimpleString": "CHAUD!",
 		"WarningAdvancedString": "ATTENTION! CHAUD!",
 		"SleepingTipAdvancedString": "Panne:",
-		"IdleTipString": "Tip:",
-		"IdleSetString": " Set:",
+		"IdleTipString": "Act:",
+		"IdleSetString": " Reg:",
 		"TipDisconnectedString": "PANNE DÉBRANCHÉE",
 		"SolderingAdvancedPowerPrompt": "Puissance: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Gain:",
+		"SettingsResetMessage": "Réglage réinit.!",
+		"LockingKeysString": "VERROUIL",
+		"UnlockingKeysString": "DEVERROU",
+		"WarningKeysLockedString": "! VERR.!"
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "A",
 		"SettingStartSleepChar": "V",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "D"
+		"SettingStartNoneChar": "D",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "V"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Source",
 				"d'alim"
 			],
 			"desc": "Source d'alimentation. Règle la tension de coupure <DC=10V S=3.3V par cellules>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Temp.",
 				"veille"
 			],
 			"desc": "Température en veille <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Délai",
 				"veille"
 			],
 			"desc": "Délai avant mise en veille <Minutes>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Délai",
 				"extinction"
 			],
 			"desc": "Délai avant extinction <Minutes>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Sensibilité",
 				"au mouvement"
 			],
 			"desc": "Sensibilité du capteur de mouvement <0=Inactif 1=Peu sensible 9=Tres sensible>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Unité de",
 				"température"
 			],
 			"desc": "Unité de température <C=Celsius F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Écran veille",
 				"détaillé"
 			],
 			"desc": "Afficher des informations détaillées lors de la veille."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Orientation",
 				"de l'écran"
 			],
 			"desc": "Orientation de l'affichage <A=Automatique G=Gaucher D=Droitier>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Temp.",
 				"Boost"
 			],
 			"desc": "Température du mode \"Boost\""
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Démarrage",
 				"automatique"
 			],
 			"desc": "Démarrer automatiquement la soudure a l'allumage <A=Activé, V=Mode Veille, D=Désactivé>"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Refroidir en",
 				"clignotant"
 			],
 			"desc": "Faire clignoter la température lors du refroidissement tant que la panne est chaude."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Étalonner",
 				"température"
 			],
 			"desc": "Étalonner température de la panne."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Réinitialisation",
 				"d'usine"
 			],
 			"desc": "Réinitialiser tous les réglages"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Étalonner",
 				"tension d'entrée"
 			],
 			"desc": "Étalonner tension d'entrée. Boutons pour ajuster, appui long pour quitter"
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Écran soudure",
 				"détaillé"
 			],
 			"desc": "Afficher des informations détaillées pendant la soudure"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Vitesse de",
 				"défilement"
 			],
 			"desc": "Vitesse de défilement de ce texte en <R=Rapide L=Lent>"
 		},
 		"TipModel": {
-						"text2": [
-				"Panne",
-				"Modèle"
+			"text2": [
+				"Modèle de",
+				"la panne"
 			],
 			"desc": "Sélection du modèle de la panne"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Calibration",
 				"simple"
 			],
 			"desc": "Calibration simple à l'aide d'eau chaude"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Calibration",
 				"avancées"
 			],
 			"desc": "Calibration avancées à l'aide d'un thermocouple sur la panne"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Puissance de",
 				"l'alimentation"
 			],
 			"desc": "Puissance de l'alimentation utilisée"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Puissance",
-				"Limite"
+				"limite"
 			],
 			"desc": "Puissance maximale utilisable <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
-				"Key +-",
-				"Inverser?"
+			"text2": [
+				"Inverser les",
+				"touches + - ?"
 			],
 			"desc": "Inversez l'assignation +/- du bouton de changement de température de la pointe."
 		},
 		"TempChangeShortStep": {
-						"text2": [
-				"Temp change",
-				"Court?"
+			"text2": [
+				"Incrément",
+				"appui court"
 			],
 			"desc": "Incrément de changement de température sur appui court."
 		},
 		"TempChangeLongStep": {
-						"text2": [
-				"Temp change",
-				"Long?"
+			"text2": [
+				"Incrément",
+				"appui long"
 			],
 			"desc": "Incrément de changement de température sur appui long."
 		},
-		"PowerPulsePower":{
-						"text2": [
-				"Power",
-				"Pulse W"
+		"PowerPulsePower": {
+			"text2": [
+				"Puissance des",
+				"impulsion W"
 			],
-			"desc": "Keep awake pulse power intensity"
+			"desc": "Puissance des impulsions pour éviter la mise en veille des batteries"
 		},
 		"TipGain": {
-						"text2": [
-				"Modify",
-				"tip gain"
+			"text2": [
+				"Modifier",
+				"gain panne"
 			],
-			"desc": "Tip gain"
+			"desc": "Modifier le gain de la panne"
+		},
+		"LockingMode": {
+			"text2": [
+				"Autoriser le",
+				"verrouillage"
+			],
+			"desc": "Permet de verrouiller les touches pendant la soudure sur un appuis long des 2 bouttons <D=Désactiver, B=Boost seulement, V=Verr. total>"
 		}
 	}
 }

--- a/Translation Editor/translation_hr.json
+++ b/Translation Editor/translation_hr.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "VRH NIJE SPOJEN!",
 		"SolderingAdvancedPowerPrompt": "Snaga: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Izvor",
 				"napajanja"
 			],
 			"desc": "Izvor napajanja. Postavlja napon isključivanja. <DC 10V> <S 3.3V po ćeliji>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Temp",
 				"spavanja"
 			],
 			"desc": "Temperatura na koju se spušta lemilica nakon određenog vremena mirovanja. <C/F>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Vrijeme",
 				"spavanja"
 			],
 			"desc": "Vrijeme mirovanja nakon kojega lemilica spušta temperaturu. <Minute/Sekunde>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Vrijeme",
 				"gašenja"
 			],
 			"desc": "Vrijeme mirovanja nakon kojega će se lemilica ugasiti. <Minute>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Osjetljivost",
 				"pokreta"
 			],
 			"desc": "Osjetljivost prepoznavanja pokreta. <0=Ugašeno, 1=Najmanje osjetljivo, 9=Najosjetljivije>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Jedinica",
 				"temperature"
 			],
 			"desc": "Jedinica temperature. <C=Celzij, F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Detalji",
 				"pri čekanju"
 			],
 			"desc": "Prikazivanje detaljnih informacija tijekom čekanja."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Rotacija",
 				"ekrana"
 			],
 			"desc": "Orijentacija ekrana. <A=Automatski, L=Ljevoruki, D=Desnoruki>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Boost",
 				"temp"
 			],
 			"desc": "Temperatura u pojačanom (Boost) načinu."
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Auto",
 				"start"
 			],
 			"desc": "Ako je aktivno, lemilica po uključivanju napajanja odmah počinje grijati."
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Upozorenje",
 				"pri hlađenju"
 			],
 			"desc": "Bljeskanje temperature prilikom hlađenja, ako je lemilica vruća."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibracija",
 				"temperature"
 			],
 			"desc": "Kalibriranje temperature mjeri razliku temperatura vrška i drške, dok je lemilica hladna."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Tvorničke",
 				"postavke"
 			],
 			"desc": "Vraćanje svih postavki na tvorničke vrijednosti."
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibracija",
 				"napona napajanja"
 			],
 			"desc": "Kalibracija ulaznog napona. Podešavanje gumbima, dugački pritisak za kraj."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Detalji",
 				"pri lemljenju"
 			],
 			"desc": "Prikazivanje detaljnih informacija tijekom lemljenja."
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Brzina",
 				"poruka"
 			],
 			"desc": "Brzina kretanja dugačkih poruka. <B=brzo, S=sporo>"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Model",
 				"Vrha"
 			],
 			"desc": "Odabir modela lemnog vrha"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Jednostavna",
 				"kalibracija"
 			],
 			"desc": "Kalibracija kipućom vodom"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Napredna",
 				"kalibracija"
 			],
 			"desc": "Kalibracija korištenjem termo-elementa"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Snaga",
 				"napajanja"
 			],
 			"desc": "Snaga modula za napajanje"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_hu.json
+++ b/Translation Editor/translation_hu.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "HEGY LEVÉVE",
 		"SolderingAdvancedPowerPrompt": "Telj: ",
 		"OffString": "Ki",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "J",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Áram",
 				"forrás"
 			],
 			"desc": "Áramforrás. Beállítja a lekapcsolási feszültséget. <DC 10V> <S 3.3V cellánként>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Alvási",
 				"hőfok"
 			],
 			"desc": "Alvási hőmérséklet <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Alvás",
 				"időzítő"
 			],
 			"desc": "Alvás időzítő <perc/másodperc>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Kikapcsolás",
 				"időzítő"
 			],
 			"desc": "Kikapcsolási időzítő <perc>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Mozgás",
 				"érzékenység"
 			],
 			"desc": "Mozgás érzékenység beállítása. <0.kikapcsolva 1.legkevésbé érzékeny 9.legérzékenyebb>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Hőmérséklet",
 				"mértékegysége"
 			],
 			"desc": "Hőmérséklet mértékegysége <C=Celsius F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Részletes",
 				"készenlét"
 			],
 			"desc": "Részletes információ megjelenítése kisebb betűméretben a készenléti képernyőn."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Kijelző",
 				"tájolása"
 			],
 			"desc": "Kijelző tájolása <A. automatikus B. balkezes J. jobbkezes>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Boost",
 				"hőfok"
 			],
 			"desc": "Hőmérséklet \"boost\" módban"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Automatikus",
 				"indítás"
 			],
 			"desc": "Bekapcsolás után automatikusan lépjen forrasztás módba. T=forrasztás, S=alvó mód, F=ki"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Villogás",
 				"hűléskor"
 			],
 			"desc": "Villogjon a hőmérséklet hűlés közben, amíg a hegy forró."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Hőmérséklet",
 				"kalibrálása?"
 			],
 			"desc": "Hegy hőmérséklet-különbségének kalibrálása."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Gyári",
 				"beállítások?"
 			],
 			"desc": "Beállítások alaphelyzetbe állítása"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Bemeneti fesz",
 				"kalibrálása?"
 			],
 			"desc": "Bemeneti feszültség kalibrálása. Röviden megnyomva módosítás, hosszan megnyomva kilépés"
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Részletes",
 				"forr. kép."
 			],
 			"desc": "Részletes információk megjelenítése forrasztás közben"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Görgetés",
 				"sebessége"
 			],
 			"desc": "Szöveggörgetés sebessége"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Forrasztóhegy",
 				"modell"
 			],
 			"desc": "Forrasztóhegy modell kiválasztása"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Egyszerű",
 				"kalibráció"
 			],
 			"desc": "Egyszerű kalibrálás forró víz segítségével"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Haladó",
 				"Kalibráció"
 			],
 			"desc": "Haladó kalibrálás hegyre helyezett hőelem segítségével"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Bemeneti",
 				"teljesítmény"
 			],
 			"desc": "A tápegység által leadott teljesítmény"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Telj",
 				"maximum"
 			],
 			"desc": "Maximális teljesitmény beállitása <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"GOMB +-",
 				"Felcseréled?"
 			],
 			"desc": "A páka hömérséklet növelés csökkentési gombok felcserélése."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Hömérséklet",
 				"váltás rövid?"
 			],
 			"desc": "Hömérséklet váltás rövid gombnyomásrs bekapcsolva!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Hömérséklet",
 				"váltás hosszú?"
 			],
 			"desc": "Hömérséklet váltás hosszú gombnyomásrs bekapcsolva!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Telj power",
 				"bank üzem W"
 			],
 			"desc": "Powerbank üzemnél nem engedi a powerbankot kikapcsolni idönkénti áram felvételt generál. "
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_it.json
+++ b/Translation Editor/translation_it.json
@@ -23,7 +23,10 @@
 		"OffString": "OFF",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Guad.: ",
-		"SettingsResetMessage": "Reset effettuato"
+		"SettingsResetMessage": "Reset effettuato",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -34,7 +37,10 @@
 		"SettingStartSolderingChar": "A",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "D"
+		"SettingStartNoneChar": "D",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -68,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Sorgente",
 				"alimentaz"
 			],
 			"desc": "Scegli la sorgente di alimentazione; se a batteria, limita lo scaricamento al valore di soglia <DC: 10V; S: 3,3V per cella>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Temp",
 				"standby"
 			],
 			"desc": "Imposta la temperatura da mantenere in modalità Standby <°C/°F>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Timer",
 				"standby"
 			],
 			"desc": "Imposta il timer per entrare in modalità Standby <minuti/secondi>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Timer",
 				"spegnimento"
 			],
 			"desc": "Imposta il timer per lo spegnimento <minuti>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Sensibilità",
 				"al movimento"
 			],
 			"desc": "Imposta la sensibilità al movimento per uscire dalla modalità Standby <0: nessuna; 1: minima; 9: massima>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Unità di",
 				"temperatura"
 			],
 			"desc": "Scegli l'unità di misura per la temperatura <C: grado Celsius; F: grado Farenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Interfaccia",
 				"testuale"
 			],
 			"desc": "Mostra informazioni dettagliate all'interno della schermata principale"
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Orientamento",
 				"display"
 			],
 			"desc": "Imposta l'orientamento del display <A: automatico; S: mano sinistra; D: mano destra>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Temp",
 				"«Turbo»"
 			],
 			"desc": "Imposta la temperatura della funzione «Turbo» <°C/°F>"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Avvio",
 				"automatico"
 			],
 			"desc": "Attiva automaticamente il saldatore quando viene alimentato <A: saldatura; S: standby; D: disattiva>"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Avviso",
 				"punta calda"
 			],
 			"desc": "Evidenzia il valore di temperatura durante il raffreddamento se la punta è ancora calda"
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Calibrazione",
 				"temperatura"
 			],
 			"desc": "Calibra le rilevazioni di temperatura"
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Ripristino",
 				"impostazioni"
 			],
 			"desc": "Ripristina tutte le impostazioni"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Calibrazione",
 				"tensione"
 			],
 			"desc": "Calibra la tensione in ingresso; regola con entrambi i tasti, tieni premuto il tasto superiore per uscire"
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Dettagli",
 				"saldatura"
 			],
 			"desc": "Mostra informazioni dettagliate durante la modalità Saldatura"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Velocità",
 				"testo"
 			],
 			"desc": "Imposta la velocità di scorrimento del testo <L: lento; V: veloce>"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Modello",
 				"punta"
 			],
 			"desc": "Seleziona il modello della punta in uso"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Calibrazione",
 				"semplice"
 			],
 			"desc": "Calibra le rilevazioni di temperatura tramite l'utilizzo di acqua calda"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Calibrazione",
 				"avanzata"
 			],
 			"desc": "Calibra le rilevazioni di temperatura attraverso la termocoppia presente nella punta"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Potenza",
 				"alimentaz"
 			],
 			"desc": "Imposta la potenza massima erogabile dall'alimentatore in uso"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Limite",
 				"potenza"
 			],
 			"desc": "Imposta il valore di potenza massima erogabile al saldatore <watt>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Inversione",
 				"tasti"
 			],
 			"desc": "Inverti i tasti per aumentare o diminuire la temperatura della punta"
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp passo",
 				"breve"
 			],
 			"desc": "Imposta il «passo» dei valori di temperatura ad una breve pressione dei tasti"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp passo",
 				"lungo"
 			],
 			"desc": "Imposta il «passo» dei valori di temperatura ad una lunga pressione dei tasti"
 		},
 		"PowerPulsePower": {
-						"text2": [
+			"text2": [
 				"Potenza",
 				"impulso"
 			],
 			"desc": "Regola la potenza d'impulso per prevenire lo standby eventuale dell'alimentatore <watt>"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Guadagno",
 				"punta"
 			],
 			"desc": "Varia il guadagno della punta"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_lt.json
+++ b/Translation Editor/translation_lt.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "ANTGAL ATJUNGTAS",
 		"SolderingAdvancedPowerPrompt": "Maitinimas: ",
 		"OffString": "Išj",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Maitinimo",
 				"šaltinis"
 			],
 			"desc": "Išjungimo įtampa. <DC 10V arba celių (S) kiekis (3.3V per celę)>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Miego",
 				"temperat."
 			],
 			"desc": "Miego temperatūra <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Miego",
 				"laikas"
 			],
 			"desc": "Miego laikas <minutės/sekundės>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Išjungimo",
 				"laikas"
 			],
 			"desc": "Išjungimo laikas <minutės>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Jautrumas",
 				"judesiui"
 			],
 			"desc": "Jautrumas judesiui <0 - išjungta, 1 - mažiausias, 9 - didžiausias>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Temperatūros",
 				"vienetai"
 			],
 			"desc": "Temperatūros vienetai <C - Celsijus, F - Farenheitas>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Detalus lauki",
 				"mo ekranas"
 			],
 			"desc": "Ar rodyti papildomą informaciją mažesniu šriftu laukimo ekrane"
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Ekrano",
 				"orientacija"
 			],
 			"desc": "Ekrano orientacija <A - automatinė, K - kairiarankiams, D - dešiniarankiams>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Turbo",
 				"temperat."
 			],
 			"desc": "Temperatūra turbo režimu"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Auto",
 				"paleidimas"
 			],
 			"desc": "Ar pradėti kaitininti iš karto įjungus lituoklį"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Atvėsimo",
 				"mirksėjimas"
 			],
 			"desc": "Ar mirksėti temperatūrą ekrane kol vėstantis antgalis vis dar karštas"
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibruoti",
 				"temperatūrą?"
 			],
 			"desc": "Antgalio temperatūros kalibravimas"
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Atstatyti",
 				"nustatymus?"
 			],
 			"desc": "Nustatyti nustatymus iš naujo"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibruoti",
 				"įvesties įtampą?"
 			],
 			"desc": "Įvesties įtampos kalibravimas. Trumpai paspauskite, norėdami nustatyti, ilgai paspauskite, kad išeitumėte"
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Detalus lita-",
 				"vimo ekranas"
 			],
 			"desc": "Ar rodyti išsamią informaciją lituojant"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Greitas apr",
 				"ašym. slink"
 			],
 			"desc": "Greitis, kuriuo šis tekstas slenka"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Antgalio",
 				"modelis"
 			],
 			"desc": "Antgalio modelio pasirinkimas"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Paprasta",
 				"kalibracija"
 			],
 			"desc": "Paprasta kalibracija naudojant karštą vandienį"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Išplėstinė",
 				"kalibracija"
 			],
 			"desc": "Išplėstinė kalibracija naudojant termoelementą"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Galia",
 				"vatais"
 			],
 			"desc": "Maitinimo bloko galia vatais"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_nl.json
+++ b/Translation Editor/translation_nl.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "TIP LOSGEKOPPELD",
 		"SolderingAdvancedPowerPrompt": "vermogen: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Spannings-",
 				"bron"
 			],
 			"desc": "Spanningsbron. Stelt drempelspanning in. <DC 10V> <S 3.3V per cel>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Slaap",
 				"temp"
 			],
 			"desc": "Temperatuur in slaapstand <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Slaap",
 				"time-out"
 			],
 			"desc": "Slaapstand time-out <Minuten/Seconden>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Uitschakel",
 				"time-out"
 			],
 			"desc": "Automatisch afsluiten time-out <Minuten>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Bewegings-",
 				"gevoeligheid"
 			],
 			"desc": "Bewegingsgevoeligheid <0.uit 1.minst gevoelig 9.meest gevoelig>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Temperatuur",
 				"eenheid"
 			],
 			"desc": "Temperatuureenheid <C=Celsius F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Gedetailleerd",
 				"slaapscherm"
 			],
 			"desc": "Gedetailleerde informatie weergeven in een kleiner lettertype op het slaapscherm."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Scherm-",
 				"oriëntatie"
 			],
 			"desc": "Schermoriëntatie <A. Automatisch L. Linkshandig R. Rechtshandig>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Boost",
 				"temp"
 			],
 			"desc": "Temperatuur in boostmodes"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Auto",
 				"start"
 			],
 			"desc": "Breng de soldeerbout direct op temperatuur bij het opstarten. T=Soldeertemperatuur, S=Slaapstand-temperatuur, F=Uit"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Afkoel",
 				"flikker"
 			],
 			"desc": "Temperatuur laten flikkeren in het hoofdmenu als de soldeerpunt aan het afkoelen is."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Calibreer",
 				"temperatuur?"
 			],
 			"desc": "Temperatuursafwijking van de soldeerpunt calibreren."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Instellingen",
 				"resetten?"
 			],
 			"desc": "Alle instellingen terugzetten."
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Calibreer",
 				"input-voltage?"
 			],
 			"desc": "VIN Calibreren. Knoppen lang ingedrukt houden om te bevestigen."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Gedetailleerd",
 				"soldeerscherm"
 			],
 			"desc": "Gedetailleerde informatie weergeven in een kleiner lettertype op het soldeerscherm."
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Scroll",
 				"snelheid"
 			],
 			"desc": "Snelheid waarmee de tekst scrolt."
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Tip",
 				"Model"
 			],
 			"desc": "Tip Model selection"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Simple",
 				"Calibration"
 			],
 			"desc": "Simple Calibration using Hot water"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Advanced",
 				"Calibration"
 			],
 			"desc": "Advanced calibration using thermocouple on the tip"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Wattage"
 			],
 			"desc": "Power Wattage of the power adapter used"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_nl_be.json
+++ b/Translation Editor/translation_nl_be.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "Punt ONTKOPPELD",
 		"SolderingAdvancedPowerPrompt": "Vermogen: ",
 		"OffString": "Uit",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Spannings-",
 				"bron"
 			],
 			"desc": "Spanningsbron. Stelt minimumspanning in. <DC 10V> <S 3.3V per cel>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Slaap",
 				"temp"
 			],
 			"desc": "Temperatuur in slaapstand <°C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Slaap",
 				"time-out"
 			],
 			"desc": "Slaapstand time-out <Minuten/Seconden>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Uitschakel",
 				"time-out"
 			],
 			"desc": "Automatisch afsluiten time-out <Minuten>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Bewegings-",
 				"gevoeligheid"
 			],
 			"desc": "Bewegingsgevoeligheid <0.uit 1.minst gevoelig 9.meest gevoelig>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Temperatuur",
 				"schaal"
 			],
 			"desc": "Temperatuurschaal <°C=Celsius °F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Gedetailleerd",
 				"slaapscherm"
 			],
 			"desc": "Gedetailleerde informatie in een kleiner lettertype in het slaapscherm."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Scherm-",
 				"oriëntatie"
 			],
 			"desc": "Schermoriëntatie <A. Automatisch L. Linkshandig R. Rechtshandig>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Verhogings",
 				"temp"
 			],
 			"desc": "Verhogingstemperatuur"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Auto",
 				"start"
 			],
 			"desc": "Breng de soldeerbout op temperatuur bij het opstarten. T=Soldeertemperatuur, S=Slaapstand-temperatuur, F=Uit"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Afkoel",
 				"knipper"
 			],
 			"desc": "Temperatuur knippert in hoofdmenu tijdens afkoeling."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Calibreer",
 				"temperatuur?"
 			],
 			"desc": "Temperatuur van de punt calibreren."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Instellingen",
 				"resetten?"
 			],
 			"desc": "Alle instellingen resetten."
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Calibreer",
 				"voedingsspanning?"
 			],
 			"desc": "VIN Calibreren. Bevestigen door knoppen lang in te drukken."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Gedetailleerd",
 				"soldeerscherm"
 			],
 			"desc": "Gedetailleerde informatie in kleiner lettertype in soldeerscherm."
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Scrol",
 				"snelheid"
 			],
 			"desc": "Scrolsnelheid van de tekst."
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Punt",
 				"Model"
 			],
 			"desc": "Gekozen punt"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Eenvoudige",
 				"Calibrering"
 			],
 			"desc": "Calibrering met heet water"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Gevorderde",
 				"Calibrering"
 			],
 			"desc": "Calibrering met thermokoppel"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Vermogen",
 				"Watt"
 			],
 			"desc": "Vermogen van de adapter"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_no.json
+++ b/Translation Editor/translation_no.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "SPISS FRAKOBLET",
 		"SolderingAdvancedPowerPrompt": "Effekt: ",
 		"OffString": "Av",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "H",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "D",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "I"
+		"SettingStartNoneChar": "I",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Kilde",
 				""
 			],
 			"desc": "Strømforsyning. Sett nedre spenning for automatisk nedstenging. <DC 10V <S 3.3V per celle"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"DTmp",
 				""
 			],
 			"desc": "Dvaletemperatur <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"",
 				""
 			],
 			"desc": "Tid før dvale <Minutter/Sekunder"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"AvTid",
 				""
 			],
 			"desc": "Tid før automatisk nedstenging <Minutter"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"BSensr",
 				""
 			],
 			"desc": "Bevegelsesfølsomhet <0.Inaktiv 1.Minst følsom 9.Mest følsom"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"TmpEnh",
 				""
 			],
 			"desc": "Temperaturskala <C=Celsius F=Fahrenheit"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"AvDvSk",
 				""
 			],
 			"desc": "Vis detaljert informasjon med liten skrift på dvaleskjermen."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"SkRetn",
 				""
 			],
 			"desc": "Skjermretning <A. Automatisk V. Venstrehendt H. Høyrehendt"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"KTmp",
 				""
 			],
 			"desc": "Temperatur i \"kraft\"-modus"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"AStart",
 				""
 			],
 			"desc": "Start automatisk med lodding når strøm kobles til. L=Lodding, D=Dvale, I=Inaktiv"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"KjBlnk",
 				""
 			],
 			"desc": "Blink temperaturen på skjermen mens spissen fortsatt er varm."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"TempKal?",
 				""
 			],
 			"desc": "Kalibrer spiss-temperatur."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"TilbStl?",
 				""
 			],
 			"desc": "Tilbakestill alle innstillinger"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"KalSpIn?",
 				""
 			],
 			"desc": "Kalibrer spenning. Knappene justerer. Langt trykk for å gå ut"
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"AvLdSk",
 				""
 			],
 			"desc": "Vis detaljert informasjon ved lodding"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"RullHa",
 				""
 			],
 			"desc": "Hastigheten på rulletekst"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Tip",
 				"Model"
 			],
 			"desc": "Tip Model selection"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Simple",
 				"Calibration"
 			],
 			"desc": "Simple Calibration using Hot water"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Advanced",
 				"Calibration"
 			],
 			"desc": "Advanced calibration using thermocouple on the tip"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Wattage"
 			],
 			"desc": "Power Wattage of the power adapter used"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_pl.json
+++ b/Translation Editor/translation_pl.json
@@ -24,7 +24,10 @@
 		"OffString": "Wyłącz",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Twój zysk:",
-		"SettingsResetMessage": "Ustawienia zostały\nzresetowane!"
+		"SettingsResetMessage": "Ustawienia zostały\nzresetowane!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "P",
@@ -35,7 +38,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "Z",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "B"
+		"SettingStartNoneChar": "B",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -69,186 +75,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Źródło",
 				"zasilania"
 			],
 			"desc": "Źródło zasilania. Ustaw napięcie odcięcia. <DC 10V> <S 3.3V dla ogniw Li>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Temperatura",
 				"uśpienia"
 			],
 			"desc": "Temperatura uśpienia <°C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Czas",
 				"uśpienia"
 			],
 			"desc": "Czas uśpienia <minuty/sekundy>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Czas",
 				"wyłączenia"
 			],
 			"desc": "Czas wyłączenia <minuty>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Czułość",
 				"ruchu"
 			],
 			"desc": "Czułość ruchu <0.Wyłączona 1.Minimalna 9.Maksymalna>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Jednostka",
 				"temperatury"
 			],
 			"desc": "Jednostka temperatury <C=Celsius F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Mniejsza",
 				"czcionka"
 			],
 			"desc": "Wyświetla szczegółowe informacje za pomocą mniejszej czcionki na ekranie bezczynności"
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Orientacja",
 				"wyświetlacza"
 			],
 			"desc": "Orientacja wyświetlacza <A - automatyczna, L - leworęczna, P - praworęczna>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Temperatura",
 				"w trybie boost"
 			],
 			"desc": "Temperatura w trybie \"boost\" "
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Automatyczne",
 				"uruchamianie"
 			],
 			"desc": "Automatyczne uruchamianie trybu lutowania po włączeniu zasilania.<B - wyłączone, T - lutowanie, Z - uśpienie, O - uśpienie w temp. pokojowej"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Migająca",
 				"temperatura"
 			],
 			"desc": "Temperatura na ekranie miga, gdy grot jest jeszcze gorący."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibracja",
 				"temp. grota"
 			],
 			"desc": "Kalibracja temperatury grota lutownicy"
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Ustawienia",
 				"fabryczne"
 			],
 			"desc": "Zresetuje wszystkie ustawienia!"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibracja",
 				"napięcia"
 			],
 			"desc": "Kalibracja napięcia wejściowego. Krótkie naciśnięcie, aby ustawić, długie naciśnięcie, aby wyjść."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Szczegółowe",
 				"informacje"
 			],
 			"desc": "Wyświetl szczegółowe informacje podczas lutowania"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Szybkość",
 				"tekstu"
 			],
 			"desc": "Szybkość przewijania tekstu"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Model",
 				"grota"
 			],
 			"desc": "Wybór grotu"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Prosta",
 				"kalibracja"
 			],
 			"desc": "Prosta kalibracja, używając gorącej wody"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Zaawansowana",
 				"kalibracja"
 			],
 			"desc": "Zaawansowana kalibracja za pomocą termoelementu na grocie"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Moc",
 				"w W"
 			],
 			"desc": "Moc używanego zasilacza w Wattach"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Limit",
 				"mocy"
 			],
 			"desc": "Maksymalna moc w W, jakiej może użyć lutownica"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Zamień przyciski",
 				"+ -"
 			],
 			"desc": "Zamienia działanie przycisków zmiany temperatury grotu"
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Szybka zmiana",
 				"temperatury"
 			],
 			"desc": "Zmiany temperatury krok po korku, po krótkim naciśnięciu przycisku"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Wolna zmiana",
 				"temperatury"
 			],
 			"desc": "Zmiany temperatury krok po korku, po długim naciśnięciu przycisku"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Moc pulsu",
 				"w W"
 			],
 			"desc": "Utrzymuj intensywność mocy pulsu"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Zmodyfikowany",
 				"zysk grotu"
 			],
 			"desc": "Zysk grotu"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_pt.json
+++ b/Translation Editor/translation_pt.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "SEM PONTA",
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Fonte",
 				"alimentação"
 			],
 			"desc": "Fonte de alimentação. Define a tensão de corte. <DC=10V> <S=3.3V/célula>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Temperat.",
 				"repouso"
 			],
 			"desc": "Temperatura de repouso <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Tempo",
 				"repouso"
 			],
 			"desc": "Tempo para repouso <Minutos/Segundos>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Tempo",
 				"desligam."
 			],
 			"desc": "Tempo para desligamento <Minutos>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Sensibilidade",
 				"movimento"
 			],
 			"desc": "Sensibilidade ao movimento <0=Desligado 1=Menor 9=Maior>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Unidade",
 				"temperatura"
 			],
 			"desc": "Unidade de temperatura <C=Celsius F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Tela repouso",
 				"avançada"
 			],
 			"desc": "Exibe informações avançadas quando em espera"
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Orientação",
 				"tela"
 			],
 			"desc": "Orientação da tela <A.utomática C.anhoto D.estro>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Modo turbo",
 				"temperat."
 			],
 			"desc": "Ajuste de temperatura do modo \"turbo\""
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Partida",
 				"automática"
 			],
 			"desc": "Aquece a ponta automaticamente ao ligar"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Piscar ao",
 				"arrefecer"
 			],
 			"desc": "Faz o valor da temperatura piscar durante o arrefecimento"
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Calibrar",
 				"temperatura"
 			],
 			"desc": "Calibra a temperatura"
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Reset de",
 				"fábrica?"
 			],
 			"desc": "Reverte todos ajustes"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Calibrar",
 				"tensão"
 			],
 			"desc": "Calibra a tensão de alimentação. Use os botões para ajustar o valor. Mantenha pressionado para sair"
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Tela trabalho",
 				"avançada"
 			],
 			"desc": "Exibe informações avançadas durante o uso"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Velocidade",
 				"texto ajuda"
 			],
 			"desc": "Velocidade a que o texto é exibido"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Ponta",
 				"Modelo"
 			],
 			"desc": "Selecção de modelo de ponta"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Calibração",
 				"Simples"
 			],
 			"desc": "Calibração simples com água quente"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Calibração",
 				"Avançada"
 			],
 			"desc": "Calibração avançada com um termopar na ponta"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Potência",
 				"Fonte"
 			],
 			"desc": "Potência da fonte usada (Watt)"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_ru.json
+++ b/Translation Editor/translation_ru.json
@@ -23,7 +23,10 @@
 		"OffString": "Выкл.",
 		"ResetOKMessage": "Сброс OK",
 		"YourGainMessage": "Прирост:",
-		"SettingsResetMessage": "Настройки сброшены!"
+		"SettingsResetMessage": "Настройки сброшены!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "П",
@@ -34,7 +37,10 @@
 		"SettingStartSolderingChar": "П",
 		"SettingStartSleepChar": "О",
 		"SettingStartSleepOffChar": "К",
-		"SettingStartNoneChar": "В"
+		"SettingStartNoneChar": "В",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -68,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Источник",
 				"питания"
 			],
 			"desc": "Источник питания. Устанавливает напряжение отсечки. <DC 10В> <S 3.3В на ячейку, без лимита мощности>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Темп.",
 				"ожидания"
 			],
 			"desc": "Температура режима ожидания"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Таймаут",
 				"ожидания"
 			],
 			"desc": "Время до перехода в режим ожидания <Минуты/Секунды>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Таймаут",
 				"выключения"
 			],
 			"desc": "Время до отключения паяльника <Минуты>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Чувствительн.",
 				"акселерометра"
 			],
 			"desc": "Чувствительность акселерометра <0=Выкл., 1=Мин., 9=Макс.>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Единицы",
 				"температуры"
 			],
 			"desc": "Единицы измерения температуры <C=Цельcия, F=Фаренгейта>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Подробный",
 				"реж. ожидания"
 			],
 			"desc": "Отображать детальную информацию уменьшенным шрифтом на экране ожидания"
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Ориентация",
 				"экрана"
 			],
 			"desc": "Ориентация экрана <А=Авто, Л=Левая рука, П=Правая рука>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"t° турбо",
 				"режима"
 			],
 			"desc": "Температура жала в турбо-режиме"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Авто",
 				"старт"
 			],
 			"desc": "Режим, в котором запускается паяльник при подаче питания <П=Пайка, О=Ожидание, К=Ожидание при комн. темп., В=Выкл.>"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Мигание t°",
 				"при остывании"
 			],
 			"desc": "Мигать температурой на экране охлаждения, пока жало еще горячее"
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Калибровка",
 				"температуры"
 			],
 			"desc": "Калибровка термодатчика жала"
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Сброс",
 				"Настроек"
 			],
 			"desc": "Сброс настроек к значеням по умолчанию"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Калибровка",
 				"напряжения"
 			],
 			"desc": "Калибровка входного напряжения <длинное нажатие для выхода>"
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Подробный",
 				"экран пайки"
 			],
 			"desc": "Показывать детальную информацию на экране пайки"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Скорость",
 				"текста"
 			],
 			"desc": "Скорость прокрутки текста <М=медленно, Б=быстро>"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Модель",
 				"жала"
 			],
 			"desc": "Выбор модели жала"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Упрощенная",
 				"калибровка"
 			],
 			"desc": "Упрощенная калибровка с использованием горячей воды"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Улучшенная",
 				"калибровка"
 			],
 			"desc": "Улучшенная калибровка с импользованием термопары жала"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Мощность",
 				"питания"
 			],
 			"desc": "Мощность используемого источника питания"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Максимальная",
 				"мощность"
 			],
 			"desc": "Максимальная мощность, которую может использовать паяльник <Ватт>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Инвертировать",
 				"кнопки"
 			],
 			"desc": "Инвертировать кнопки изменения температуры"
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Шаг темп.",
 				"кор. наж."
 			],
 			"desc": "Шаг изменения температуры при коротком нажатии кнопок"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Шаг темп.",
 				"длин. наж."
 			],
 			"desc": "Шаг изменения температуры при длинном нажатии кнопок"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
-			"desc": "Keep awake pulse power intensity"			
+			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_sk.json
+++ b/Translation Editor/translation_sk.json
@@ -23,7 +23,10 @@
 		"OffString": "Vyp",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Zisk:",
-		"SettingsResetMessage": "Nast. Obnovené!"
+		"SettingsResetMessage": "Nast. Obnovené!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "P",
@@ -34,7 +37,10 @@
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "K",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "N"
+		"SettingStartNoneChar": "N",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -248,6 +254,13 @@
 				"hrotu"
 			],
 			"desc": "Úprava zisku hrotu"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_sl.json
+++ b/Translation Editor/translation_sl.json
@@ -22,7 +22,11 @@
 		"SolderingAdvancedPowerPrompt": "Moč: ",
 		"OffString": "Izk",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Ojačan.:"
+		"YourGainMessage": "Ojačan.:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -33,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -67,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Vir",
 				"napajanja"
 			],
 			"desc": "Vir napajanja. Nastavi napetost izklopa. <DC 10V> <S 3.3V na celico>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Temp. med",
 				"spanjem"
 			],
 			"desc": "Temperatura med spanjem <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Čas do",
 				"spanja"
 			],
 			"desc": "Čas pred spanjem <minute/sekunde>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Čas do",
 				"izklopa"
 			],
 			"desc": "Čas pred izklopom <minute>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Občutljivost",
 				"premikanja"
 			],
 			"desc": "Občutljivost premikanja <0.izklopljeno 1.najmanj 9.najbolj občutljivo>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Enota za",
 				"temperaturo"
 			],
 			"desc": "Enota za temperaturo <C=celzija F=fahrenheita>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Več info na",
 				"zaslonu v mir"
 			],
 			"desc": "Prikaže več informacij z manjšo pisavo na zaslonu med mirovanjem."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Orientacija",
 				"zaslona"
 			],
 			"desc": "Orientacija zaslona <S. samodejno L. levo D. desno>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Temperat.",
 				"v boost"
 			],
 			"desc": "Temperatura v \"boost\" načinu"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Samodejni",
 				"zagon"
 			],
 			"desc": "Samodejno segrej konico ob vklopu. T=segrej, S=spanje, F=izklop"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Utripanje med",
 				"hlajenjem"
 			],
 			"desc": "Utripaj temperaturo med hlajenjem, ko je konica še vroča."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibriram",
 				"temperaturo?"
 			],
 			"desc": "Kalibracija temperature na konici."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Tovarniške",
 				"nastavitve?"
 			],
 			"desc": "Ponastavitev vseh nastavitev"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibriram",
 				"vhodno napetost?"
 			],
 			"desc": "Kalibracija VIN. Nastavitve z gumbi, dolgi pritisk za izhod."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Več info na",
 				"zaslonu spaj."
 			],
 			"desc": "Prikaže več informacij z manjšo pisavo na zaslonu med spajkanjem."
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Hitrost",
 				"besedila"
 			],
 			"desc": "Hitrost, s katero se prikazuje besedilo"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Model",
 				"konice"
 			],
 			"desc": "Izbira tipa konice"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Preprosta",
 				"kalibracija"
 			],
 			"desc": "Preprosta kalibracija z vročo vodo."
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Napredna",
 				"kalibracija"
 			],
 			"desc": "Napredna kalibracija s termočlenom na konici"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Moč napajalnega",
 				"vira"
 			],
 			"desc": "Moč v W napajalnega vira"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_sr_cyrl.json
+++ b/Translation Editor/translation_sr_cyrl.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "ВРХ НИЈЕ СПОЈЕН",
 		"SolderingAdvancedPowerPrompt": "Снага: ",
 		"OffString": "Иск",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "Д",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Врста",
 				"напајања"
 			],
 			"desc": "Тип напајања; одређује најнижи радни напон. <DC=адаптер (10V), S=батерија (3,3V по ћелији)>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Темп.",
 				"спавања"
 			],
 			"desc": "Температура на коју се спушта лемилица након одређеног времена мировања. <C/F>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Време до",
 				"спавања"
 			],
 			"desc": "Време мировања након кога лемилица спушта температуру. <M=минути, S=секунде>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Време до",
 				"гашења"
 			],
 			"desc": "Време мировања након кога се лемилица гаси. <M=минути>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Осетљивост",
 				"на покрет"
 			],
 			"desc": "Осетљивост сензора покрета. <0=искључено, 1=најмање осетљиво, 9=најосетљивије>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Јединица",
 				"температуре"
 			],
 			"desc": "Јединице у којима се приказује температура. <C=целзијус, F=фаренхајт>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Детаљи током",
 				"мировања"
 			],
 			"desc": "Приказивање детаљних информација на екрану током мировања."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Оријентација",
 				"екрана"
 			],
 			"desc": "Како је окренут екран. <А=аутоматски, Л=за леворуке, Д=за десноруке>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Темп.",
 				"појачања"
 			],
 			"desc": "Температура врха лемилице у току појачања."
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Врући",
 				"старт"
 			],
 			"desc": "Лемилица одмах по покретању прелази у режим лемљења и греје се."
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Упозорење",
 				"при хлађењу"
 			],
 			"desc": "Приказ температуре трепће приликом хлађења докле год је врх и даље врућ."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Калибрација",
 				"температуре"
 			],
 			"desc": "Калибрисање одступања температуре врха у односу на дршку."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Фабричке",
 				"поставке"
 			],
 			"desc": "Враћање свих поставки на фабричке вредности."
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Калибрација",
 				"улазног напона"
 			],
 			"desc": "Калибрисање улазног напона. Подешава се на тастере; дуги притисак за крај."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Детаљи током",
 				"лемљења"
 			],
 			"desc": "Приказивање детаљних информација на екрану током лемљења."
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Брзина",
 				"порука"
 			],
 			"desc": "Брзина кретања описних порука попут ове. <С=споро, Б=брзо>"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Модел",
 				"врха"
 			],
 			"desc": "Одабир модела лемног врха."
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Једноставна",
 				"калибрација"
 			],
 			"desc": "Једноставна калибрација кипућом водом."
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Напредна",
 				"калибрација"
 			],
 			"desc": "Напредна калибрација помоћу термопара."
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Улазна",
 				"снага"
 			],
 			"desc": "Снага напајања у ватима."
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_sr_latn.json
+++ b/Translation Editor/translation_sr_latn.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "VRH NIJE SPOJEN",
 		"SolderingAdvancedPowerPrompt": "Snaga: ",
 		"OffString": "Isk",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Vrsta",
 				"napajanja"
 			],
 			"desc": "Tip napajanja; određuje najniži radni napon. <DC=adapter (10V), S=baterija (3,3V po ćeliji)>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Temp.",
 				"spavanja"
 			],
 			"desc": "Temperatura na koju se spušta lemilica nakon određenog vremena mirovanja. <C/F>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Vreme do",
 				"spavanja"
 			],
 			"desc": "Vreme mirovanja nakon koga lemilica spušta temperaturu. <M=minuti, S=sekunde>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Vreme do",
 				"gašenja"
 			],
 			"desc": "Vreme mirovanja nakon koga se lemilica gasi. <M=minuti>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Osetljivost",
 				"na pokret"
 			],
 			"desc": "Osetljivost senzora pokreta. <0=isključeno, 1=najmanje osetljivo, 9=najosetljivije>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Jedinica",
 				"temperature"
 			],
 			"desc": "Jedinice u kojima se prikazuje temperatura. <C=celzijus, F=farenhajt>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Detalji tokom",
 				"mirovanja"
 			],
 			"desc": "Prikazivanje detaljnih informacija na ekranu tokom mirovanja."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Orijentacija",
 				"ekrana"
 			],
 			"desc": "Kako je okrenut ekran. <A=automatski, L=za levoruke, D=za desnoruke>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Temp.",
 				"pojačanja"
 			],
 			"desc": "Temperatura vrha lemilice u toku pojačanja."
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Vrući",
 				"start"
 			],
 			"desc": "Lemilica odmah po pokretanju prelazi u režim lemljenja i greje se."
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Upozorenje",
 				"pri hlađenju"
 			],
 			"desc": "Prikaz temperature trepće prilikom hlađenja dokle god je vrh i dalje vruć."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibracija",
 				"temperature"
 			],
 			"desc": "Kalibrisanje odstupanja temperature vrha u odnosu na dršku."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Fabričke",
 				"postavke"
 			],
 			"desc": "Vraćanje svih postavki na fabričke vrednosti."
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibracija",
 				"ulaznog napona"
 			],
 			"desc": "Kalibrisanje ulaznog napona. Podešava se na tastere; dugi pritisak za kraj."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Detalji tokom",
 				"lemljenja"
 			],
 			"desc": "Prikazivanje detaljnih informacija na ekranu tokom lemljenja."
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Brzina",
 				"poruka"
 			],
 			"desc": "Brzina kretanja opisnih poruka poput ove. <S=sporo, B=brzo>"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Model",
 				"vrha"
 			],
 			"desc": "Odabir modela lemnog vrha."
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Jednostavna",
 				"kalibracija"
 			],
 			"desc": "Jednostavna kalibracija kipućom vodom."
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Napredna",
 				"kalibracija"
 			],
 			"desc": "Napredna kalibracija pomoću termopara."
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Ulazna",
 				"snaga"
 			],
 			"desc": "Snaga napajanja u vatima."
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_sv.json
+++ b/Translation Editor/translation_sv.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "SPETS URTAGEN",
 		"SolderingAdvancedPowerPrompt": "Ström: ",
 		"OffString": "Av",
-		"ResetOKMessage": "Reset OK"
+		"ResetOKMessage": "Reset OK",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "H",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Ström-",
 				"källa"
 			],
 			"desc": "Strömkälla. Anger lägsta spänning. <DC 10V> <S 3.3V per cell>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Vilo-",
 				"temp"
 			],
 			"desc": "Vilotemperatur <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Vilo-",
 				"timeout"
 			],
 			"desc": "Vilo-timeout <Minuter/Seconder>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Avstängn.",
 				"timeout"
 			],
 			"desc": "Avstängnings-timeout <Minuter>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Rörelse-",
 				"känslighet"
 			],
 			"desc": "Rörelsekänslighet <0.Av 1.minst känslig 9.mest känslig>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Temperatur-",
 				"enheter"
 			],
 			"desc": "Temperaturenhet <C=Celsius F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Detaljerad",
 				"vid inaktiv"
 			],
 			"desc": "Visa detaljerad information i mindre typsnitt när inaktiv."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Visnings",
 				"läge"
 			],
 			"desc": "Visningsläge <A. Automatisk V. Vänsterhänt H. Högerhänt>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Turbo-",
 				"temp"
 			],
 			"desc": "Temperatur i \"turbo\"-läge"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Auto",
 				"start"
 			],
 			"desc": "Startar automatiskt lödpennan vid uppstart. T=Lödning, S=Viloläge, F=Av"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Nedkylnings-",
 				"blink"
 			],
 			"desc": "Blinka temperaturen medan spetsen kyls av och fortfarande är varm."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibrera",
 				"temperatur?"
 			],
 			"desc": "Kalibrera spets-kompensation."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Fabriks-",
 				"inställ?"
 			],
 			"desc": "Återställ alla inställningar"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Kalibrera",
 				"inspänning?"
 			],
 			"desc": "Inspänningskalibrering. Knapparna justerar, håll inne för avslut"
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Detaljerad",
 				"lödng.skärm"
 			],
 			"desc": "Visa detaljerad information vid lödning"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Beskrivning",
 				"rullhast."
 			],
 			"desc": "Hastighet som den här texten rullar i"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Tip",
 				"Model"
 			],
 			"desc": "Tip Model selection"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Simple",
 				"Calibration"
 			],
 			"desc": "Simple Calibration using Hot water"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Advanced",
 				"Calibration"
 			],
 			"desc": "Advanced calibration using thermocouple on the tip"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Wattage"
 			],
 			"desc": "Power Wattage of the power adapter used"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_tr.json
+++ b/Translation Editor/translation_tr.json
@@ -21,7 +21,12 @@
 		"TipDisconnectedString": "UÇ ÇIKARILDI",
 		"SolderingAdvancedPowerPrompt": "Güç: ",
 		"OffString": "Kapalı",
-		"ResetOKMessage": "Reset Tamam"
+		"ResetOKMessage": "Reset Tamam",
+		"YourGainMessage": "Your gain:",
+		"SettingsResetMessage": "Settings were\nreset!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -32,7 +37,10 @@
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",
-		"SettingStartNoneChar": "F"
+		"SettingStartNoneChar": "F",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -66,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"PWRSC",
 				""
 			],
 			"desc": "Güç Kaynağı. kesim geriliminı ayarlar. <DC 10V> <S 3.3V hücre başına>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"STMP",
 				""
 			],
 			"desc": "Uyku Sıcaklığı <C>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"STME",
 				""
 			],
 			"desc": "Uyku Zaman Aşımı <Dakika/Saniye>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"SHTME",
 				""
 			],
 			"desc": "Kapatma Zaman Aşımı <Dakika>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"MSENSE",
 				""
 			],
 			"desc": "Hareket Hassasiyeti <0.Kapalı 1.En az duyarlı 9.En duyarlı>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"TMPUNT",
 				""
 			],
 			"desc": "Sıcaklık Ünitesi <C=Celsius F=Fahrenheit>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"ADVIDL",
 				""
 			],
 			"desc": "Boş ekranda ayrıntılı bilgileri daha küçük bir yazı tipi ile göster."
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"DSPROT",
 				""
 			],
 			"desc": "Görüntü Yönlendirme <A. Otomatik L. Solak R. Sağlak>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"BTMP",
 				""
 			],
 			"desc": "\"boost\" Modu Derecesi"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"ASTART",
 				""
 			],
 			"desc": "Güç verildiğinde otomatik olarak lehimleme modunda başlat. T=Lehimleme Modu, S= Uyku Modu,F=Kapalı"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"CLBLNK",
 				""
 			],
 			"desc": "Soğutma ekranında uç hala sıcakken derece yanıp sönsün."
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"TMP CAL?",
 				""
 			],
 			"desc": "Ucu kalibre et."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"RESET?",
 				""
 			],
 			"desc": "Bütün ayarları sıfırla"
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"CAL VIN?",
 				""
 			],
 			"desc": "VIN Kalibrasyonu. Düğmeler ayarlar, çıkmak için uzun bas."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"ADVSLD",
 				""
 			],
 			"desc": "Lehimleme yaparken detaylı bilgi göster"
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"DESCSP",
 				""
 			],
 			"desc": "Speed this text scrolls past at"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Uç",
 				"Modeli"
 			],
 			"desc": "Uç Modeli seçimi"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Basit",
 				"Kalibrasyon"
 			],
 			"desc": "Sıcak su kullanarak basit kalibrasyon"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Gelişmiş",
 				"Kalibrasyon"
 			],
 			"desc": "Uçtaki ısı sensörünü kullanarak gelişmiş kalibrasyon"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Güç",
 				"Miktarı(W)"
 			],
 			"desc": "Kullanılan adaptörün güç miktarı"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Power",
 				"Limit"
 			],
 			"desc": "Maximum power the iron can use <Watts>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Key +-",
 				"reverse?"
 			],
 			"desc": "Reverse the tip temperature change buttons plus minus assignment."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"short?"
 			],
 			"desc": "Temperature change steps on short button press!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Temp change",
 				"long?"
 			],
 			"desc": "Temperature change steps on long button press!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Power",
 				"Pulse W"
 			],
 			"desc": "Keep awake pulse power intensity"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translation_uk.json
+++ b/Translation Editor/translation_uk.json
@@ -23,7 +23,10 @@
 		"OffString": "Вимк",
 		"ResetOKMessage": "Скидання OK",
 		"YourGainMessage": "Приріст:",
-		"SettingsResetMessage": "Налаштування скинуті!"
+		"SettingsResetMessage": "Налаштування скинуті!",
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "П",
@@ -34,7 +37,10 @@
 		"SettingStartSolderingChar": "П",
 		"SettingStartSleepChar": "О",
 		"SettingStartSleepOffChar": "К",
-		"SettingStartNoneChar": "В"
+		"SettingStartNoneChar": "В",
+		"SettingLockDisableChar": "D",
+		"SettingLockBoostChar": "B",
+		"SettingLockFullChar": "F"
 	},
 	"menuGroups": {
 		"SolderingMenu": {
@@ -68,186 +74,193 @@
 	},
 	"menuOptions": {
 		"PowerSource": {
-						"text2": [
+			"text2": [
 				"Джерело",
 				"живлення"
 			],
 			"desc": "Встановлення напруги відключення. <DC - 10V, 3S - 9.9V, 4S - 13.2V, 5S - 16.5V, 6S - 19.8V>"
 		},
 		"SleepTemperature": {
-						"text2": [
+			"text2": [
 				"Темпер.",
 				"сну"
 			],
 			"desc": "Температура режиму очікування <C°/F°>"
 		},
 		"SleepTimeout": {
-						"text2": [
+			"text2": [
 				"Тайм-аут",
 				"сну"
 			],
 			"desc": "Час до переходу в режим очікування <Хвилини/Секунди>"
 		},
 		"ShutdownTimeout": {
-						"text2": [
+			"text2": [
 				"Часу до",
 				"вимкнення"
 			],
 			"desc": "Час до відключення <Хвилини>"
 		},
 		"MotionSensitivity": {
-						"text2": [
+			"text2": [
 				"Чутл. сенсо-",
 				"ру руху"
 			],
 			"desc": "Акселерометр <0 - Вимк. 1 - мін. чутливості 9 - макс. чутливості>"
 		},
 		"TemperatureUnit": {
-						"text2": [
+			"text2": [
 				"Формат темпе-",
 				"ратури(C°/F°)"
 			],
 			"desc": "Одиниця виміру температури <C - Цельсій, F - Фаренгейт>"
 		},
 		"AdvancedIdle": {
-						"text2": [
+			"text2": [
 				"Детальний ре-",
 				"жим очікуван."
 			],
 			"desc": "Показувати детальну інформацію маленьким шрифтом на домашньому екрані"
 		},
 		"DisplayRotation": {
-						"text2": [
+			"text2": [
 				"Автоповорот",
 				"екрану"
 			],
 			"desc": "Орієнтація дисплея <A - Автоповорот, Л - Лівша, П - Правша>"
 		},
 		"BoostTemperature": {
-						"text2": [
+			"text2": [
 				"Темпер.",
 				"Турбо"
 			],
 			"desc": "Температура в Турбо-режимі"
 		},
 		"AutoStart": {
-						"text2": [
+			"text2": [
 				"Гарячий",
 				"старт"
 			],
 			"desc": "Режим з яким запускається паяльник при подачі живлення <П=Пайка, О=Очікування, К=Очікування при кімн. темп., В=Вимк.>"
 		},
 		"CooldownBlink": {
-						"text2": [
+			"text2": [
 				"Показ t° при",
 				"охолодж."
 			],
 			"desc": "Показувати температуру на екрані охолодження, поки жало залишається гарячим, при цьому екран моргає"
 		},
 		"TemperatureCalibration": {
-						"text2": [
+			"text2": [
 				"Калібровка",
 				"температури"
 			],
 			"desc": "Калібрування температурного датчика."
 		},
 		"SettingsReset": {
-						"text2": [
+			"text2": [
 				"Скинути всі",
 				"налаштування?"
 			],
 			"desc": "Скидання всіх параметрів до стандартних значень."
 		},
 		"VoltageCalibration": {
-						"text2": [
+			"text2": [
 				"Калібрування",
 				"напруги"
 			],
 			"desc": "Калібрування напруги входу. Налаштувати кнопками, натиснути і утримати щоб завершити."
 		},
 		"AdvancedSoldering": {
-						"text2": [
+			"text2": [
 				"Детальний ре-",
 				"жим пайки"
 			],
 			"desc": "Показувати детальну інформацію при пайці."
 		},
 		"ScrollingSpeed": {
-						"text2": [
+			"text2": [
 				"Швидкість",
 				"тексту"
 			],
 			"desc": "Швидкість прокрутки тексту <П=повільно, Ш=швидко>"
 		},
 		"TipModel": {
-						"text2": [
+			"text2": [
 				"Модель",
 				"Жало"
 			],
 			"desc": "Вибір моделі жала"
 		},
 		"SimpleCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Просте",
 				"Калібрування"
 			],
 			"desc": "Просте калібрування з використанням гарячої води"
 		},
 		"AdvancedCalibrationMode": {
-						"text2": [
+			"text2": [
 				"Детальне",
 				"Калібрування"
 			],
 			"desc": "Калібрування за допомогою термопари"
 		},
 		"PowerInput": {
-						"text2": [
+			"text2": [
 				"Потужність",
 				"дж. живл."
 			],
 			"desc": "Потужність джерела живлення в Ватах"
 		},
 		"PowerLimit": {
-						"text2": [
+			"text2": [
 				"Макс.",
 				"потуж."
 			],
 			"desc": "Макс. потужність, яку може використовувати паяльник <Ват>"
 		},
 		"ReverseButtonTempChange": {
-						"text2": [
+			"text2": [
 				"Інвертувати",
 				"кнопки +-?"
 			],
 			"desc": "Інвертувати кнопки зміни температури."
 		},
 		"TempChangeShortStep": {
-						"text2": [
+			"text2": [
 				"Зм. темп.",
 				"коротко?"
 			],
 			"desc": "Змінювати температуру при короткому натисканні!"
 		},
 		"TempChangeLongStep": {
-						"text2": [
+			"text2": [
 				"Зм. темп.",
 				"довго?"
 			],
 			"desc": "Змінювати температуру при довгому натисканні!"
 		},
-		"PowerPulsePower":{
-						"text2": [
+		"PowerPulsePower": {
+			"text2": [
 				"Пульс.",
 				"Навантаж."
 			],
 			"desc": "Деякі PowerBank-и з часом вимк. живлення, якщо пристрій споживає дуже мало енергії (це потрібно щоб паяльник не вимкнувся з часом)"
 		},
 		"TipGain": {
-						"text2": [
+			"text2": [
 				"Modify",
 				"tip gain"
 			],
 			"desc": "Tip gain"
+		},
+		"LockingMode": {
+			"text2": [
+				"Allow buttons",
+				"locking"
+			],
+			"desc": "When soldering, long press on both buttons lock them <D=Disable, B=Boost only, F=Full locking>"
 		}
 	}
 }

--- a/Translation Editor/translations_def.js
+++ b/Translation Editor/translations_def.js
@@ -94,6 +94,21 @@ var def =
 			"id": "SettingsResetMessage",
 			"maxLen": 16,
 			"default": "Settings were\nreset!"
+		},
+		{
+			"id": "LockingKeysString",
+			"maxLen": 8,
+			"default": "LOCKING"
+		},
+		{
+			"id": "UnlockingKeysString",
+			"maxLen": 8,
+			"default": "UNLOCK"
+		},
+		{
+			"id": "WarningKeysLockedString",
+			"maxLen": 8,
+			"default": "LOCKED!"
 		}
 	],
 	"characters": [
@@ -132,6 +147,21 @@ var def =
 		{
 			"id": "SettingStartNoneChar",
 			"len": 1
+		},
+		{
+			"id": "SettingLockDisableChar",
+			"len": 1,
+			"default": "D"
+		},
+		{
+			"id": "SettingLockBoostChar",
+			"len": 1,
+			"default": "B"
+		},
+		{
+			"id": "SettingLockFullChar",
+			"len": 1,
+			"default": "F"
 		}
 	],
 	"menuGroups": [
@@ -282,6 +312,11 @@ var def =
 			"id": "TipGain",
 			"maxLen": 6,
 			"maxLen2": 8
+		},
+		{
+			"id": "LockingMode",
+			"maxLen": 6,
+			"maxLen2": 13
 		}
 	]
 }

--- a/workspace/TS100/Core/Drivers/Buttons.cpp
+++ b/workspace/TS100/Core/Drivers/Buttons.cpp
@@ -42,7 +42,7 @@ ButtonState getButtonState() {
 			else if (currentState == 0x02)
 				return BUTTON_B_LONG;
 			else
-				return BUTTON_NONE; // Both being held case, we dont long hold this
+				return BUTTON_BOTH_LONG; // Both being held case
 		} else
 			return BUTTON_NONE;
 	} else {

--- a/workspace/TS100/Core/Drivers/Buttons.hpp
+++ b/workspace/TS100/Core/Drivers/Buttons.hpp
@@ -17,6 +17,7 @@ enum ButtonState {
 	BUTTON_F_LONG = 4, /* User is  holding the front button*/
 	BUTTON_B_LONG = 8, /* User is  holding the back button*/
 	BUTTON_BOTH = 16, /* User has pressed both buttons*/
+	BUTTON_BOTH_LONG = 32, /* User is holding both buttons*/
 
 /*
  * Note:

--- a/workspace/TS100/Core/Inc/Settings.h
+++ b/workspace/TS100/Core/Inc/Settings.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 #include "stm32f1xx_hal.h"
 #include "unit.h"
-#define SETTINGSVERSION   ( 0x21 )
+#define SETTINGSVERSION   ( 0x22 )
 /*Change this if you change the struct below to prevent people getting \
           out of sync*/
 
@@ -41,6 +41,7 @@ typedef struct {
 	uint8_t temperatureInF :1;       // Should the temp be in F or C (true is F)
 #endif
 	uint8_t descriptionScrollSpeed :1;  // Description scroll speed
+	uint8_t lockingMode :2;		// Store the locking mode
 	uint8_t KeepAwakePulse;  // Keep Awake pulse power in 0.1 watts (10 = 1Watt)
 
 	uint16_t voltageDiv;                 // Voltage divisor factor
@@ -55,6 +56,7 @@ typedef struct {
 	uint8_t ReverseButtonTempChangeEnabled; // Change the plus and minus button assigment
 	uint16_t TempChangeLongStep;   // Change the plus and minus button assigment
 	uint16_t TempChangeShortStep;  // Change the plus and minus button assigment
+
 
 	uint32_t padding;  // This is here for in case we are not an even divisor so
 					   // that nothing gets cut off

--- a/workspace/TS100/Core/Inc/Translation.h
+++ b/workspace/TS100/Core/Inc/Translation.h
@@ -15,8 +15,8 @@ extern const uint8_t USER_FONT_6x8[];
  * When SettingsShortNameType is SHORT_NAME_SINGLE_LINE
  * use SettingsShortNames as SettingsShortNames[16][1].. second column undefined
  */
-extern const char *SettingsShortNames[28][2];
-extern const char *SettingsDescriptions[28];
+extern const char *SettingsShortNames[29][2];
+extern const char *SettingsDescriptions[29];
 extern const char *SettingsMenuEntries[4];
 
 extern const char *SettingsCalibrationDone;
@@ -41,6 +41,9 @@ extern const char *OffString;
 extern const char *ResetOKMessage;
 extern const char *YourGainMessage;
 extern const char *SettingsResetMessage;
+extern const char *LockingKeysString;
+extern const char *UnlockingKeysString;
+extern const char *WarningKeysLockedString;
 
 extern const char *SettingTrueChar;
 extern const char *SettingFalseChar;
@@ -51,6 +54,9 @@ extern const char *SettingStartSolderingChar;
 extern const char *SettingStartSleepChar;
 extern const char *SettingStartSleepOffChar;
 extern const char *SettingStartNoneChar;
+extern const char *SettingLockDisableChar;
+extern const char *SettingLockBoostChar;
+extern const char *SettingLockFullChar;
 
 extern const char *SettingFastChar;
 extern const char *SettingSlowChar;

--- a/workspace/TS100/Core/Src/Settings.cpp
+++ b/workspace/TS100/Core/Src/Settings.cpp
@@ -65,6 +65,7 @@ void resetSettings() {
 	systemSettings.ShutdownTime = SHUTDOWN_TIME; // How many minutes until the unit turns itself off
 	systemSettings.BoostTemp = BOOST_TEMP;    // default to 400C
 	systemSettings.autoStartMode = AUTO_START_MODE; // Auto start off for safety
+	systemSettings.lockingMode = LOCKING_MODE; // Disable locking for safety
 	systemSettings.coolingTempBlink = COOLING_TEMP_BLINK; // Blink the temperature on the cooling screen when its > 50C
 #ifdef ENABLED_FAHRENHEIT_SUPPORT
 	systemSettings.temperatureInF = TEMPERATURE_INF;          // default to 0

--- a/workspace/TS100/Core/Src/gui.cpp
+++ b/workspace/TS100/Core/Src/gui.cpp
@@ -50,6 +50,8 @@ static bool settings_setBoostTemp(void);
 static void settings_displayBoostTemp(void);
 static bool settings_setAutomaticStartMode(void);
 static void settings_displayAutomaticStartMode(void);
+static bool settings_setLockingMode(void);
+static void settings_displayLockingMode(void);
 static bool settings_setCoolingBlinkEnabled(void);
 static void settings_displayCoolingBlinkEnabled(void);
 static bool settings_setResetSettings(void);
@@ -88,6 +90,7 @@ static bool settings_enterAdvancedMenu(void);
  * 	Auto Start
  *  Temp change short step
  *  Temp change long step
+ *	Locking Mode
 
  *
  * Power Saving
@@ -156,6 +159,8 @@ const menuitem solderingMenu[] = {
 		settings_displayTempChangeShortStep }, /*Temp change short step*/
 { (const char*) SettingsDescriptions[23], settings_setTempChangeLongStep,
 		settings_displayTempChangeLongStep }, /*Temp change long step*/
+{ (const char*) SettingsDescriptions[26], settings_setLockingMode,
+		settings_displayLockingMode }, /*Locking Mode*/
 { NULL, NULL, NULL }                // end of menu marker. DO NOT REMOVE
 };
 const menuitem UIMenu[] = {
@@ -616,6 +621,31 @@ static void settings_displayAutomaticStartMode(void) {
 		break;
 	default:
 		OLED::print(SettingStartNoneChar);
+		break;
+	}
+}
+
+static bool settings_setLockingMode(void) {
+	systemSettings.lockingMode++;
+	systemSettings.lockingMode %= 3;
+	return systemSettings.lockingMode == 2;
+}
+
+static void settings_displayLockingMode(void) {
+	printShortDescription(26, 7);
+
+	switch (systemSettings.lockingMode) {
+	case 0:
+		OLED::print(SettingLockDisableChar);
+		break;
+	case 1:
+		OLED::print(SettingLockBoostChar);
+		break;
+	case 2:
+		OLED::print(SettingLockFullChar);
+		break;
+	default:
+		OLED::print(SettingLockDisableChar);
 		break;
 	}
 }

--- a/workspace/TS100/Core/Threads/GUIThread.cpp
+++ b/workspace/TS100/Core/Threads/GUIThread.cpp
@@ -409,8 +409,10 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
 	 * PID control
 	 * --> Long hold back button to exit
 	 * --> Double button to exit
+	 * --> Long hold double button to toggle key lock
 	 */
 	bool boostModeOn = false;
+	bool buttonsLocked = false;
 
 	uint32_t sleepThres = 0;
 	if (systemSettings.SleepTime < 6)
@@ -425,34 +427,86 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
 	}
 	for (;;) {
 		ButtonState buttons = getButtonState();
-		switch (buttons) {
-		case BUTTON_NONE:
-			// stay
-			boostModeOn = false;
-			break;
-		case BUTTON_BOTH:
-			// exit
-			return;
-			break;
-		case BUTTON_B_LONG:
-			return;  // exit on back long hold
-			break;
-		case BUTTON_F_LONG:
-			// if boost mode is enabled turn it on
-			if (systemSettings.BoostTemp)
-				boostModeOn = true;
-			break;
-		case BUTTON_F_SHORT:
-		case BUTTON_B_SHORT: {
-			uint16_t oldTemp = systemSettings.SolderingTemp;
-			gui_solderingTempAdjust();  // goto adjust temp mode
-			if (oldTemp != systemSettings.SolderingTemp) {
-				saveSettings();  // only save on change
+		if (buttonsLocked && (systemSettings.lockingMode != 0)) { // If buttons locked
+			switch (buttons) {
+			case BUTTON_NONE:
+				// stay
+				boostModeOn = false;
+				break;
+			case BUTTON_BOTH_LONG:
+				// Unlock buttons
+				buttonsLocked = false;
+				OLED::setCursor(0, 0);
+				OLED::clearScreen();
+				OLED::setFont(0);
+				OLED::print(UnlockingKeysString);
+				OLED::refresh();
+				waitForButtonPressOrTimeout(1000);
+				break;
+			case BUTTON_F_LONG:
+				// if boost mode is enabled turn it on
+				if (systemSettings.BoostTemp && (systemSettings.lockingMode == 1)) {
+					boostModeOn = true;
+					break;
+				};
+				// fall through
+			case BUTTON_BOTH:
+			case BUTTON_B_LONG:
+			case BUTTON_F_SHORT:
+			case BUTTON_B_SHORT:
+				// Do nothing and display a lock warming
+				OLED::setCursor(0, 0);
+				OLED::clearScreen();
+				OLED::setFont(0);
+				OLED::print(WarningKeysLockedString);
+				OLED::refresh();
+				waitForButtonPressOrTimeout(500);
+				break;
+			default:
+				break;
 			}
-		}
-			break;
-		default:
-			break;
+		} else { // Button not locked
+			switch (buttons) {
+				case BUTTON_NONE:
+				// stay
+				boostModeOn = false;
+				break;
+				case BUTTON_BOTH:
+				// exit
+				return;
+				break;
+				case BUTTON_B_LONG:
+				return;  // exit on back long hold
+				break;
+				case BUTTON_F_LONG:
+				// if boost mode is enabled turn it on
+				if (systemSettings.BoostTemp)
+				boostModeOn = true;
+				break;
+				case BUTTON_F_SHORT:
+				case BUTTON_B_SHORT: {
+					uint16_t oldTemp = systemSettings.SolderingTemp;
+					gui_solderingTempAdjust();  // goto adjust temp mode
+					if (oldTemp != systemSettings.SolderingTemp) {
+						saveSettings();  // only save on change
+					}
+				}
+				break;
+				case BUTTON_BOTH_LONG:
+					if (systemSettings.lockingMode != 0) {
+						// Lock buttons
+						buttonsLocked = true;
+						OLED::setCursor(0, 0);
+						OLED::clearScreen();
+						OLED::setFont(0);
+						OLED::print(LockingKeysString);
+						OLED::refresh();
+						waitForButtonPressOrTimeout(1000);
+					}
+					break;
+				default:
+				break;
+			}
 		}
 		// else we update the screen information
 		OLED::setCursor(0, 0);

--- a/workspace/TS100/configuration.h
+++ b/workspace/TS100/configuration.h
@@ -41,6 +41,16 @@
 #define AUTO_START_MODE           0         // Default to none
 
 /**
+ * Locking Mode
+ * When in soldering mode a long press on both keys toggle the lock of the buttons
+ * Possible values are:
+ *  0 - Desactivated
+ *  1 - Lock except boost
+ *  2 - Full lock
+ */
+#define LOCKING_MODE           0         // Default to desactivated for safety
+
+/**
  * OLED Orientation
  * 
  */


### PR DESCRIPTION
This add a locking mode that lock the buttons when soldering to avoid accidental press.

A long press on both buttons toggle it (only on the soldering gui)

In the soldering config menu you can set it to :
- Disable (default)
- Lock except Boost mode
- Lock everything

Tested on TS100 only