### PR TITLE
Improve linux flashing script

### DIFF
--- a/Flashing/flash_ts100_linux.sh
+++ b/Flashing/flash_ts100_linux.sh
@@ -66,7 +66,7 @@ function wait_for_ts100 {
 
 function mount_ts100 {
     mkdir -p "$DIR_TMP"
-    sudo mount -t msdos -o uid=$UID "$DEVICE" "$DIR_TMP"
+    sudo mount -t vfat -o uid=$UID,sync "$DEVICE" "$DIR_TMP"
     if [ $? -ne 0 ]; then
         echo "Failed to mount $DEVICE on $DIR_TMP"
         exit 1


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Improve the linux flashing script

- Arch complains about `msdos` not being supported with no obvious package missing & `vfat` *seems* more common.
    
- Additionally, it didn't work for me without the `sync` option & that makes sense, since it forces synchronous writes

* **Other information**:
In this issue (https://github.com/Ralim/ts100/issues/11) it was suggested that the `msdos` fs type works better than `vfat` by some, but there seems to be no obvious reason for that to be the case.